### PR TITLE
Add tooltips to script parameters

### DIFF
--- a/web/js/components/checkbox.js
+++ b/web/js/components/checkbox.js
@@ -1,4 +1,4 @@
-function Checkbox(name, defaultValue) {
+function Checkbox(name, defaultValue, description) {
     AbstractInput.call(this);
 
     var label = document.createElement("label");
@@ -15,6 +15,7 @@ function Checkbox(name, defaultValue) {
 
     this.panel.appendChild(this.checkBox);
     this.panel.appendChild(label);
+    this.panel.title = description;
 }
 
 Checkbox.prototype = new AbstractInput();

--- a/web/js/components/checkbox.js
+++ b/web/js/components/checkbox.js
@@ -15,7 +15,9 @@ function Checkbox(name, defaultValue, description) {
 
     this.panel.appendChild(this.checkBox);
     this.panel.appendChild(label);
-    this.panel.title = description;
+    if (!isEmptyString(description)) {
+        this.panel.title = description;
+    }
 }
 
 Checkbox.prototype = new AbstractInput();

--- a/web/js/components/combobox.js
+++ b/web/js/components/combobox.js
@@ -1,4 +1,4 @@
-function Combobox(name, defaultValue, required, values) {
+function Combobox(name, defaultValue, required, values, description) {
     AbstractInput.call(this);
 
     this.required = required;
@@ -40,6 +40,7 @@ function Combobox(name, defaultValue, required, values) {
 
     this.panel.appendChild(this.selectField);
     this.panel.appendChild(label);
+    this.panel.title = description;
 }
 
 Combobox.prototype = new AbstractInput();

--- a/web/js/components/combobox.js
+++ b/web/js/components/combobox.js
@@ -40,7 +40,9 @@ function Combobox(name, defaultValue, required, values, description) {
 
     this.panel.appendChild(this.selectField);
     this.panel.appendChild(label);
-    this.panel.title = description;
+    if (!isEmptyString(description)) {
+        this.panel.title = description;
+    }
 }
 
 Combobox.prototype = new AbstractInput();

--- a/web/js/components/textfield.js
+++ b/web/js/components/textfield.js
@@ -13,7 +13,6 @@ function TextField(name, defaultValue, required, type, min, max, description) {
     this.field = document.createElement("input");
     this.field.id = name;
     this.field.type = "text";
-    this.field.title = description;
 
     if (!isNull(this.type)) {
         if (this.type == "int") {

--- a/web/js/components/textfield.js
+++ b/web/js/components/textfield.js
@@ -36,7 +36,9 @@ function TextField(name, defaultValue, required, type, min, max, description) {
 
     this.panel.appendChild(this.field);
     this.panel.appendChild(label);
-    this.panel.title = description;
+    if (!isEmptyString(description)) {
+        this.panel.title = description;
+    }
 }
 
 TextField.prototype = new AbstractInput();

--- a/web/js/components/textfield.js
+++ b/web/js/components/textfield.js
@@ -1,4 +1,4 @@
-function TextField(name, defaultValue, required, type, min, max) {
+function TextField(name, defaultValue, required, type, min, max, description) {
     AbstractInput.call(this);
 
     this.required = required;
@@ -13,6 +13,7 @@ function TextField(name, defaultValue, required, type, min, max) {
     this.field = document.createElement("input");
     this.field.id = name;
     this.field.type = "text";
+    this.field.title = description;
 
     if (!isNull(this.type)) {
         if (this.type == "int") {
@@ -36,6 +37,7 @@ function TextField(name, defaultValue, required, type, min, max) {
 
     this.panel.appendChild(this.field);
     this.panel.appendChild(label);
+    this.panel.title = description;
 }
 
 TextField.prototype = new AbstractInput();

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -440,16 +440,16 @@ function showScript(activeScript) {
 }
 
 function createParameterControl(parameter) {
-
     if (parameter.withoutValue) {
-        return new Checkbox(parameter.name, parameter.default);
+        return new Checkbox(parameter.name, parameter.default, parameter.description);
 
     } else if (parameter.type == "list") {
         return new Combobox(
             parameter.name,
             parameter.default,
             parameter.required,
-            parameter.values);
+            parameter.values,
+            parameter.description);
 
     } else {
         return new TextField(
@@ -458,7 +458,8 @@ function createParameterControl(parameter) {
             parameter.required,
             parameter.type,
             parameter.min,
-            parameter.max);
+            parameter.max,
+            parameter.description);
     }
 }
 


### PR DESCRIPTION
In the previous version the descriptions of parameters specified in the .json-file is unused in the web ui.
This update adds tooltips to the `<input>`s (combobox, checkbox, textfield)