### PR TITLE
Update launcher.py to avoid the No module named 'server' error

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import sys
+import os, sys
 
 sys.path.append("src")
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 import server
 


### PR DESCRIPTION
Changing the working directory to the app's directory to avoid the "ImportError: No module named 'server'" error be begginner in Python.