### PR TITLE
Allow config dir and config file to be specified from command lines

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,10 @@ args = vars(parser.parse_args())
 TEMP_FOLDER = 'temp'
 
 CONFIG_FOLDER = args['config_dir']
-SERVER_CONF_PATH = os.path.join(CONFIG_FOLDER, args['config_file'])
+if os.path.isabs(args['config_file']):
+    SERVER_CONF_PATH = args['config_file']
+else:
+    SERVER_CONF_PATH = os.path.join(CONFIG_FOLDER, args['config_file'])
 LOGGER = logging.getLogger('main')
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import logging.config
@@ -18,10 +19,15 @@ from model import server_conf
 from utils import tool_utils, file_utils
 from web import server
 
+parser = argparse.ArgumentParser(description='Launch script-server.')
+parser.add_argument('-d', '--config-dir', default='conf')
+parser.add_argument('-f', '--config-file', default='conf.json')
+args = vars(parser.parse_args())
+
 TEMP_FOLDER = 'temp'
 
-CONFIG_FOLDER = 'conf'
-SERVER_CONF_PATH = os.path.join(CONFIG_FOLDER, 'conf.json')
+CONFIG_FOLDER = args['config_dir']
+SERVER_CONF_PATH = os.path.join(CONFIG_FOLDER, args['config_file'])
 LOGGER = logging.getLogger('main')
 
 


### PR DESCRIPTION
This allows the currently hardcoded config dir and config files to be set on the command line.

The main driver behind this would be to have separate systemd unit files that refer to different configs.

eg

/lib/systemd/system/script-server@.service

```
[Unit]
Description=Script Server
After=network.target
StartLimitIntervalSec=0

[Service]
Type=simple
Restart=always
RestartSec=1
ExecStart=/usr/bin/python3 /opt/script-server/launcher.py --config-file %i.json

[Install]
WantedBy=multi-user.target
```

This allows different configs to be executed (maybe with different auth backends or ports or ssl config etc) as follows:

```
systemctl enable script-server@http
systemctl start script-server@http
systemctl enable script-server@https
systemctl start script-server@https

```

With matching config files:

conf/http.json

```
{
  "port": 80,
  "address": "0.0.0.0",
  "title": "Plain HTTP script server"
}
```

conf/https.json

```
{
  "port": 443,
  "address": "0.0.0.0",
  "title": "Secure HTTPS script server"
  "ssl": {
    "key_path": "conf/script-server.key",
    "cert_path": "conf/script-server.crt"
  }
}
```
