### PR TITLE
Fix endless while loop on EOF for pty process

### DIFF
--- a/src/execution/process_pty.py
+++ b/src/execution/process_pty.py
@@ -72,6 +72,8 @@ class PtyProcessWrapper(process_base.ProcessWrapper):
                     while True:
                         try:
                             chunk = os.read(self.pty_master, max_read_bytes)
+                            if not chunk:
+                                break
                             data += chunk
 
                         except BlockingIOError:


### PR DESCRIPTION
os.read spec says that when EOF is reached by the fd, an empty bytes
object is returned.