### PR TITLE
Add dockerfile #171

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:jessie-slim
+RUN apt-get update && apt-get install -y python3 curl && rm -rf /var/lib/apt/lists/*
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3 get-pip.py && rm get-pip.py
+WORKDIR /app/
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY conf /app/conf/
+COPY src /app/src/
+COPY web /app/web/
+COPY launcher.py /app/launcher.py
+EXPOSE 5000
+CMD [ "python3", "launcher.py" ]


### PR DESCRIPTION
Dockerfile for docker image build. Tested and working as expected.
Users should mount config files and scripts into docker image. `conf.json`  file ,` runners` folder , `scripts` folder.

Example usage:
```
docker run -d -p 5000:5000 \
           -v /host/path/to/conf.json:/app/conf/conf.json \
           -v /host/path/to/runners/:/app/conf/runners \
           -v /host/path/to/scripts/:/app/scripts/ \
           --name script-server \
           scriptserver0/script-server:latest
```

Example runner:
```json
$ cat /host/path/to/runners/sample.json
{
  "name": "sample script",
  "description": "sample script description",
  "script_path": "/app/scripts/sample.sh"
}
```

Example script:
```shell
$ cat /host/path/to/scripts/sample.sh
#!/bin/bash
echo "Hello sample script"
```

**Notes**: Script-server users should know it cannot access host system processes as it's nature of docker container. If script-server must has access to host system processes then docker image is not suited for this kind of task. (But not saying it's impossible)