### PR TITLE
alternative Dockerfile 

### DIFF
--- a/tools/Dockerfile_standalone
+++ b/tools/Dockerfile_standalone
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+
+RUN apt-get install -y python3-pip python3-dev \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --upgrade pip \
+  && pip3 install wheel 
+
+
+RUN wget `curl -s https://api.github.com/repos/bugy/script-server/releases/latest | grep browser_download_url | cut -d '"' -f 4` \
+  && unzip script-server.zip \
+  && pip3 install -r requirements.txt
+
+EXPOSE 5000
+CMD [ "python3", "launcher.py" ]


### PR DESCRIPTION
with ability to create container without cloning repo. 
Package ubuntu contains all necessary packages for scripts ( scp, ssh, .... ) - with existing Dockerfile ( event with using the same network ) not possible to do any "standard" operations.