### PR TITLE
Add option to retrieve username from HTTP header

### DIFF
--- a/src/auth/identification.py
+++ b/src/auth/identification.py
@@ -33,7 +33,7 @@ class IpBasedIdentification(Identification):
     COOKIE_KEY = 'client_id_token'
     EMPTY_TOKEN = (None, None)
 
-    def __init__(self, trusted_ips) -> None:
+    def __init__(self, trusted_ips, user_header_name) -> None:
         self._trusted_ips = set(trusted_ips)
         self._user_header_name = user_header_name
 

--- a/src/auth/identification.py
+++ b/src/auth/identification.py
@@ -35,6 +35,7 @@ class IpBasedIdentification(Identification):
 
     def __init__(self, trusted_ips) -> None:
         self._trusted_ips = set(trusted_ips)
+        self._user_header_name = user_header_name
 
     def identify(self, request_handler):
         remote_ip = request_handler.request.remote_ip
@@ -43,6 +44,10 @@ class IpBasedIdentification(Identification):
         if new_trusted:
             if request_handler.get_cookie(self.COOKIE_KEY):
                 request_handler.clear_cookie(self.COOKIE_KEY)
+            if self._user_header_name:
+                user_header = request_handler.request.headers.get(self._user_header_name, None)
+                if user_header:
+                    return user_header
             return self._resolve_ip(request_handler)
 
         (client_id, days_remaining) = self._read_client_token(request_handler)

--- a/src/model/server_conf.py
+++ b/src/model/server_conf.py
@@ -30,6 +30,7 @@ class ServerConfig(object):
         self.admin_users = []
         self.max_request_size_mb = None
         self.callbacks_config = None
+        self.user_header_name = None
 
     def get_port(self):
         return self.port
@@ -88,9 +89,11 @@ def from_json(conf_path, temp_folder):
     if access_config:
         allowed_users = access_config.get('allowed_users')
         user_groups = model_helper.read_dict(access_config, 'groups')
+        user_header_name = access_config.get('user_header_name')
     else:
         allowed_users = None
         user_groups = {}
+        user_header_name = None
 
     auth_config = json_object.get('auth')
     if auth_config:
@@ -119,6 +122,7 @@ def from_json(conf_path, temp_folder):
     config.logging_config = parse_logging_config(json_object)
     config.user_groups = user_groups
     config.admin_users = admin_users
+    config.user_header_name = user_header_name
 
     config.max_request_size_mb = read_int_from_config('max_request_size', json_object, default=10)
 

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -783,7 +783,7 @@ def init(server_config: ServerConfig,
     if auth.is_enabled():
         identification = AuthBasedIdentification(auth)
     else:
-        identification = IpBasedIdentification(server_config.trusted_ips)
+        identification = IpBasedIdentification(server_config.trusted_ips, server_config.user_header_name)
 
     downloads_folder = file_download_feature.get_result_files_folder()
 


### PR DESCRIPTION
This PR extends the IP based identification to allow the username to be extracted from a specific HTTP request header defined in the server config as follows:

```
{
  ...
  "access": {
    "allowed_users": [ ... ],
    "admin_users": [ ... ],
    "user_header_name": "X-Auth-Name"
  }
}
```

This header is only used if the request comes from a trusted IP.

If the configured header does not exist, the identification falls back to the IP based method.

The use case for this, in our case, is an instance of script-server that sits behind a reverse proxy (HAProxy in this case) that does authentication itself, then adds various headers to the request (username, email address, display name etc).