### PR TITLE
Logs - replace forward slash (/) with underscore

### DIFF
--- a/src/execution/logging.py
+++ b/src/execution/logging.py
@@ -367,7 +367,7 @@ class LogNameCreator:
         if not filename.lower().endswith('.log'):
             filename += '.log'
 
-        filename = filename.replace(" ", "_")
+        filename = filename.replace(" ", "_").replace("/", "_")
 
         return filename
 

--- a/src/tests/execution_filename_test.py
+++ b/src/tests/execution_filename_test.py
@@ -12,8 +12,8 @@ class TestLogNameCreator(unittest.TestCase):
         self.assertEqual(filename, 'my_script_bugy_180506_083026.log')
 
     def test_custom_date_format(self):
-        filename = self.create_filename(date_format='xx%y/%m/%d-%fxx')
-        self.assertEqual(filename, 'my_script_bugy_xx18/05/06-234000xx.log')
+        filename = self.create_filename(date_format='xx%y-%m-%d_%fxx')
+        self.assertEqual(filename, 'my_script_bugy_xx18-05-06_234000xx.log')
 
     def test_custom_name_id_only(self):
         filename = self.create_filename(filename_pattern='$ID')


### PR DESCRIPTION
Hi,

I was playing with script-server for the first time today and noticed you cannot use '/' in the script name as it breaks the logging on the filesystem due to... well, obvious reasons :-)
```
FileNotFoundError: [Errno 2] No such file or directory: 'logs/processes/Group_add/remove_a_member_<host>_200307_134140.log'
```
There might be a better approach to do this as more chars may break this.

For your consideration 