### PR TITLE
chore(docs): Fix admin interface screenshots link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ No script modifications are needed - you configure each script in Script server 
 
 [DEMO server](https://script-server.net/)
 
-[Admin interface screenshots](/bugy/script-server/wiki/Admin-interface)
+[Admin interface screenshots](https://github.com/bugy/script-server/wiki/Admin-interface)
 
 ## Features
 - Different types of script parameters (text, flag, dropdown, file upload, etc.)


### PR DESCRIPTION
Fix link in README, which previously lead to 404 page, instead of actual wiki page with screenshots.

----

Looks like GitHub understands relative links as paths inside the repo, which results in attempt to open `https://github.com/bugy/script-server/blob/master/bugy/script-server/wiki/Admin-interface` and not the actual wiki page with screenshots

<img width="670" alt="Screen Shot 2020-04-24 at 20 30 28" src="https://user-images.githubusercontent.com/21325/80245227-9b658b00-866a-11ea-8a83-4ca250a6d510.png">
