### PR TITLE
escape path delimiter in script name

### DIFF
--- a/src/config/config_service.py
+++ b/src/config/config_service.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger('config_service')
 
 
 def _script_name_to_file_name(script_name):
-    escaped_whitespaces = re.sub('\\s', '_', script_name)
+    escaped_whitespaces = re.sub('[\\s/]+', '_', script_name).strip("_")
     filename = to_filename(escaped_whitespaces)
     return filename + '.json'
 


### PR DESCRIPTION
If we will try to create script with path in name, like '/usr/bash' - the script config file will be created by absolute path /usr/bash.json

It's happens because slash wasnt escaped and `path = os.path.join(self._script_configs_folder, _script_name_to_file_name(name))` will not use self._script_configs_folder if second parameter - absolute path
