### PR TITLE
Two issue has been added:

### DIFF
--- a/src/auth/auth_base.py
+++ b/src/auth/auth_base.py
@@ -5,6 +5,7 @@ class Authenticator(metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         self._client_visible_config = {}
         self.auth_type = None
+        self.auth_expiration_days = 30
 
     @abc.abstractmethod
     def authenticate(self, request_handler):

--- a/src/auth/tornado_auth.py
+++ b/src/auth/tornado_auth.py
@@ -70,7 +70,7 @@ class TornadoAuth():
 
         LOGGER.info('Authenticated user ' + username)
 
-        request_handler.set_secure_cookie('username', username)
+        request_handler.set_secure_cookie('username', username, expires_days=self.authenticator.auth_expiration_days)
 
         path = tornado.escape.url_unescape(request_handler.get_argument('next', '/'))
 

--- a/src/main.py
+++ b/src/main.py
@@ -26,10 +26,12 @@ from web.client import tornado_client_config
 parser = argparse.ArgumentParser(description='Launch script-server.')
 parser.add_argument('-d', '--config-dir', default='conf')
 parser.add_argument('-f', '--config-file', default='conf.json')
+parser.add_argument('-l', '--log-folder', default='logs')
+parser.add_argument('-t', '--tmp-folder', default='temp')
 args = vars(parser.parse_args())
 
-TEMP_FOLDER = 'temp'
-LOG_FOLDER = 'logs'
+TEMP_FOLDER = args['tmp_folder']
+LOG_FOLDER = args['log_folder']
 
 CONFIG_FOLDER = args['config_dir']
 if os.path.isabs(args['config_file']):

--- a/src/model/server_conf.py
+++ b/src/model/server_conf.py
@@ -156,6 +156,8 @@ def create_authenticator(auth_object, temp_folder):
     else:
         raise Exception(auth_type + ' auth is not supported')
 
+    authenticator.auth_expiration_days = float(auth_object.get('expiration_days')) if auth_object.get('expiration_days') is not None else 30
+
     authenticator.auth_type = auth_type
 
     return authenticator

--- a/src/model/server_conf.py
+++ b/src/model/server_conf.py
@@ -156,7 +156,7 @@ def create_authenticator(auth_object, temp_folder):
     else:
         raise Exception(auth_type + ' auth is not supported')
 
-    authenticator.auth_expiration_days = float(auth_object.get('expiration_days')) if auth_object.get('expiration_days') is not None else 30
+    authenticator.auth_expiration_days = float(auth_object.get('expiration_days', 30)) 
 
     authenticator.auth_type = auth_type
 


### PR DESCRIPTION
1. --log-folder and --tmp-folder command line arguments to get the files locations more flexible
2. "expiration_days" (non-intеger values are avalible also) in server config file's section "auth" to limit auth cookie life time. The default value is 30 days if the param is underfined.

 Changes to be committed:
	modified:   src/auth/auth_base.py
	modified:   src/auth/tornado_auth.py
	modified:   src/main.py
	modified:   src/model/server_conf.py