### PR TITLE
allow auth.username and auth.audit_name in script values and descriptions

### DIFF
--- a/src/model/model_helper.py
+++ b/src/model/model_helper.py
@@ -189,7 +189,9 @@ def fill_parameter_values(parameter_configs, template, values):
 
 def replace_auth_vars(text, username, audit_name):
     result = text
-
+    if not result:
+        return
+        
     if not username:
         username = ''
     if not audit_name:

--- a/src/model/model_helper.py
+++ b/src/model/model_helper.py
@@ -190,7 +190,7 @@ def fill_parameter_values(parameter_configs, template, values):
 def replace_auth_vars(text, username, audit_name):
     result = text
     if not result:
-        return
+        return result
         
     if not username:
         username = ''

--- a/src/model/parameter_config.py
+++ b/src/model/parameter_config.py
@@ -67,7 +67,7 @@ class ParameterModel(object):
         self.repeat_param = read_bool_from_config('repeat_param', config, default=True)
         self.env_var = config.get('env_var')
         self.no_value = read_bool_from_config('no_value', config, default=False)
-        self.description = resolve_default(config.get('description'), self._username, self._audit_name, self._working_dir)
+        self.description = replace_auth_vars(config.get('description'), self._username, self._audit_name)
         self.required = read_bool_from_config('required', config, default=False)
         self.min = config.get('min')
         self.max = config.get('max')
@@ -75,7 +75,7 @@ class ParameterModel(object):
         self.separator = config.get('separator', ',')
         self.multiple_arguments = read_bool_from_config('multiple_arguments', config, default=False)
         self.same_arg_param = read_bool_from_config('same_arg_param', config, default=False)
-        self.default = resolve_default(config.get('default'), self._username, self._audit_name, self._working_dir)
+        self.default = _resolve_default(config.get('default'), self._username, self._audit_name, self._working_dir)
         self.file_dir = _resolve_file_dir(config, 'file_dir')
         self._list_files_dir = _resolve_list_files_dir(self.file_dir, self._working_dir)
         self.file_extensions = _resolve_file_extensions(config, 'file_extensions')
@@ -180,7 +180,7 @@ class ParameterModel(object):
             return ConstValuesProvider(values_config)
 
         elif 'script' in values_config:
-            script = resolve_default(values_config['script'], self._username, self._audit_name, self._working_dir)
+            script = replace_auth_vars(values_config['script'], self._username, self._audit_name)
 
             if '${' not in script:
                 return ScriptValuesProvider(script)
@@ -400,7 +400,7 @@ class ParameterModel(object):
         return os.path.normpath(os.path.join(self._list_files_dir, *child_path))
 
 
-def resolve_default(default, username, audit_name, working_dir):
+def _resolve_default(default, username, audit_name, working_dir):
     if not default:
         return default
 

--- a/src/model/parameter_config.py
+++ b/src/model/parameter_config.py
@@ -67,7 +67,7 @@ class ParameterModel(object):
         self.repeat_param = read_bool_from_config('repeat_param', config, default=True)
         self.env_var = config.get('env_var')
         self.no_value = read_bool_from_config('no_value', config, default=False)
-        self.description = config.get('description')
+        self.description = resolve_default(config.get('description'), self._username, self._audit_name, self._working_dir)
         self.required = read_bool_from_config('required', config, default=False)
         self.min = config.get('min')
         self.max = config.get('max')
@@ -75,7 +75,7 @@ class ParameterModel(object):
         self.separator = config.get('separator', ',')
         self.multiple_arguments = read_bool_from_config('multiple_arguments', config, default=False)
         self.same_arg_param = read_bool_from_config('same_arg_param', config, default=False)
-        self.default = _resolve_default(config.get('default'), self._username, self._audit_name, self._working_dir)
+        self.default = resolve_default(config.get('default'), self._username, self._audit_name, self._working_dir)
         self.file_dir = _resolve_file_dir(config, 'file_dir')
         self._list_files_dir = _resolve_list_files_dir(self.file_dir, self._working_dir)
         self.file_extensions = _resolve_file_extensions(config, 'file_extensions')
@@ -180,7 +180,7 @@ class ParameterModel(object):
             return ConstValuesProvider(values_config)
 
         elif 'script' in values_config:
-            script = values_config['script']
+            script = resolve_default(values_config['script'], self._username, self._audit_name, self._working_dir)
 
             if '${' not in script:
                 return ScriptValuesProvider(script)
@@ -400,7 +400,7 @@ class ParameterModel(object):
         return os.path.normpath(os.path.join(self._list_files_dir, *child_path))
 
 
-def _resolve_default(default, username, audit_name, working_dir):
+def resolve_default(default, username, audit_name, working_dir):
     if not default:
         return default
 

--- a/src/model/script_config.py
+++ b/src/model/script_config.py
@@ -8,7 +8,7 @@ from auth.authorization import ANY_USER
 from model import parameter_config
 from model.model_helper import is_empty, fill_parameter_values, read_bool_from_config, InvalidValueException, \
     read_str_from_config
-from model.parameter_config import ParameterModel
+from model.parameter_config import ParameterModel, resolve_default
 from react.properties import ObservableList, ObservableDict, observable_fields, Property
 from utils import file_utils
 from utils.object_utils import merge_dicts
@@ -152,8 +152,8 @@ class ConfigModel:
             config = merge_dicts(self._original_config, self._included_config, ignored_keys=['parameters'])
 
         self.script_command = config.get('script_path')
-        self.description = config.get('description')
         self.working_directory = config.get('working_directory')
+        self.description = resolve_default(config.get('description'), self._username, self._audit_name, self.working_directory)
 
         required_terminal = read_bool_from_config('requires_terminal', config, default=self._pty_enabled_default)
         self.requires_terminal = required_terminal

--- a/src/model/script_config.py
+++ b/src/model/script_config.py
@@ -7,8 +7,8 @@ from collections import OrderedDict
 from auth.authorization import ANY_USER
 from model import parameter_config
 from model.model_helper import is_empty, fill_parameter_values, read_bool_from_config, InvalidValueException, \
-    read_str_from_config
-from model.parameter_config import ParameterModel, resolve_default
+    read_str_from_config, replace_auth_vars
+from model.parameter_config import ParameterModel
 from react.properties import ObservableList, ObservableDict, observable_fields, Property
 from utils import file_utils
 from utils.object_utils import merge_dicts
@@ -152,8 +152,8 @@ class ConfigModel:
             config = merge_dicts(self._original_config, self._included_config, ignored_keys=['parameters'])
 
         self.script_command = config.get('script_path')
+        self.description = replace_auth_vars(config.get('description'), self._username, self._audit_name)
         self.working_directory = config.get('working_directory')
-        self.description = resolve_default(config.get('description'), self._username, self._audit_name, self.working_directory)
 
         required_terminal = read_bool_from_config('requires_terminal', config, default=self._pty_enabled_default)
         self.requires_terminal = required_terminal

--- a/src/tests/parameter_config_test.py
+++ b/src/tests/parameter_config_test.py
@@ -277,7 +277,7 @@ class TestDefaultValue(unittest.TestCase):
 
     @staticmethod
     def resolve_default(value, *, username=None, audit_name=None, working_dir=None):
-        return parameter_config.resolve_default(value, username, audit_name, working_dir)
+        return parameter_config._resolve_default(value, username, audit_name, working_dir)
 
     def setUp(self):
         test_utils.setup()

--- a/src/tests/parameter_config_test.py
+++ b/src/tests/parameter_config_test.py
@@ -277,7 +277,7 @@ class TestDefaultValue(unittest.TestCase):
 
     @staticmethod
     def resolve_default(value, *, username=None, audit_name=None, working_dir=None):
-        return parameter_config._resolve_default(value, username, audit_name, working_dir)
+        return parameter_config.resolve_default(value, username, audit_name, working_dir)
 
     def setUp(self):
         test_utils.setup()


### PR DESCRIPTION
This an attempt to support https://github.com/bugy/script-server/issues/217.
I also thought having those variables templated in script's config `description` field aswell.