### PR TITLE
Max chars input validation

### DIFF
--- a/src/model/external_model.py
+++ b/src/model/external_model.py
@@ -41,6 +41,7 @@ def parameter_to_external(parameter):
         'type': parameter.type,
         'min': parameter.min,
         'max': parameter.max,
+        'max_length': parameter.max_length,
         'values': parameter.values,
         'secure': parameter.secure,
         'fileRecursive': parameter.file_recursive,

--- a/src/model/parameter_config.py
+++ b/src/model/parameter_config.py
@@ -27,6 +27,7 @@ LOGGER = logging.getLogger('script_server.parameter_config')
     'type',
     'min',
     'max',
+    'max_length',
     'constant',
     '_values_provider',
     'values',
@@ -71,6 +72,7 @@ class ParameterModel(object):
         self.required = read_bool_from_config('required', config, default=False)
         self.min = config.get('min')
         self.max = config.get('max')
+        self.max_length = config.get('max_length')
         self.secure = read_bool_from_config('secure', config, default=False)
         self.separator = config.get('separator', ',')
         self.multiple_arguments = read_bool_from_config('multiple_arguments', config, default=False)
@@ -277,6 +279,9 @@ class ParameterModel(object):
             return None
 
         if self.type == 'text':
+            if (not is_empty(self.max_length)) and (len(value) > int(self.max_length)):
+                return 'is longer than allowed char length (' \
+                        + str(len(value)) + ' > ' + str(self.max_length) + ')'
             return None
 
         if self.type == 'file_upload':
@@ -291,7 +296,7 @@ class ParameterModel(object):
             int_value = int(value)
 
             if (not is_empty(self.max)) and (int_value > int(self.max)):
-                return 'is greater than allowed value (' \
+                return 'is longer than allowed value (' \
                        + value_string + ' > ' + str(self.max) + ')'
 
             if (not is_empty(self.min)) and (int_value < int(self.min)):

--- a/web-src/src/admin/components/scripts-config/ParameterConfigForm.vue
+++ b/web-src/src/admin/components/scripts-config/ParameterConfigForm.vue
@@ -134,6 +134,7 @@
                 secure: 'secure',
                 min: 'min',
                 max: 'max',
+                max_length: 'max_length',
                 multipleArguments: 'multiple_arguments',
                 sameArgParam: 'same_arg_param',
                 separator: 'separator',
@@ -169,6 +170,7 @@
                 description: null,
                 min: null,
                 max: null,
+                max_length: null,
                 allowedValues: null,
                 allowedValuesScript: null,
                 allowedValuesFromScript: null,
@@ -193,6 +195,7 @@
                 descriptionField,
                 minField,
                 maxField: Object.assign({}, maxField),
+                maxLengthField,
                 allowedValuesScriptField,
                 allowedValuesFromScriptField,
                 defaultValueField: Object.assign({}, defaultValueField),
@@ -221,6 +224,7 @@
                         this.required = get(config, 'required', false);
                         this.min = config['min'];
                         this.max = config['max'];
+                        this.max_length = config['max_length'];
                         this.constant = !!get(config, 'constant', false);
                         this.secure = !!get(config, 'secure', false);
                         this.multipleArguments = !!get(config, 'multiple_arguments', false);

--- a/web-src/src/admin/components/scripts-config/parameter-fields.js
+++ b/web-src/src/admin/components/scripts-config/parameter-fields.js
@@ -67,6 +67,11 @@ export const allowedValuesScriptField = {
     required: true
 };
 
+export const maxLengthField = {
+    name: 'Max Characters',
+    type: 'int'
+};
+
 export const allowedValuesFromScriptField = {
     name: 'Load from script',
     withoutValue: true,

--- a/web-src/src/common/components/textfield.vue
+++ b/web-src/src/common/components/textfield.vue
@@ -151,8 +151,10 @@
 
     function getValidByTypeError(value, type, min, max, max_length) {
         if (type === 'text') {
-            if (value.length > max_length) {
-                return 'Max chars allowed: ' + max_length
+            if (max_length) {
+                if (value.length > max_length) {
+                    return 'Max chars allowed: ' + max_length
+                }
             }
         }
 

--- a/web-src/src/common/components/textfield.vue
+++ b/web-src/src/common/components/textfield.vue
@@ -121,7 +121,7 @@
                 }
 
                 if (!empty) {
-                    var typeError = getValidByTypeError(value, this.config.type, this.config.min, this.config.max);
+                    var typeError = getValidByTypeError(value, this.config.type, this.config.min, this.config.max, this.config.max_length);
                     if (!isEmptyString(typeError)) {
                         return typeError;
                     }
@@ -149,7 +149,13 @@
         }
     }
 
-    function getValidByTypeError(value, type, min, max) {
+    function getValidByTypeError(value, type, min, max, max_length) {
+        if (type === 'text') {
+            if (value.length > max_length) {
+                return 'Max chars allowed: ' + max_length
+            }
+        }
+
         if (type === 'int') {
             const isInteger = /^(((-?[1-9])(\d*))|0)$/.test(value);
             if (!isInteger) {


### PR DESCRIPTION
Adding `max_chars` config parameter to a text field.

I sometime require limit user input to specific number of chars. I've been doing this until now with-in the executed script but I find it much useful this way.