### PR TITLE
Honor X-headers for reverse proxy support

### DIFF
--- a/src/tests/web/server_test.py
+++ b/src/tests/web/server_test.py
@@ -88,6 +88,14 @@ class ServerTest(TestCase):
             {'name': 's3', 'group': None}],
             response['scripts'])
 
+    def test_redirect_honors_protocol_header(self):
+        self.start_server(12345, '127.0.0.1')
+
+        response = requests.get('http://127.0.0.1:12345/',
+            allow_redirects=False,
+            headers={'X-Forwarded-Proto': 'https'})
+        self.assertRegex(response.headers['Location'], '^https')
+
     def request(self, method, url):
         response = requests.request(method, url)
         self.assertEqual(200, response.status_code, 'Failed to execute request: ' + response.text)

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -809,7 +809,11 @@ def init(server_config: ServerConfig,
     io_loop = tornado.ioloop.IOLoop.current()
 
     global _http_server
-    _http_server = httpserver.HTTPServer(application, ssl_options=ssl_context, max_buffer_size=10 * BYTES_IN_MB)
+    _http_server = httpserver.HTTPServer(
+        application,
+        ssl_options=ssl_context,
+        max_buffer_size=10 * BYTES_IN_MB,
+        xheaders=True)
     _http_server.listen(server_config.port, address=server_config.address)
 
     intercept_stop_when_running_scripts(io_loop, execution_service)


### PR DESCRIPTION
https://github.com/bugy/script-server/wiki/Reverse-Proxy-setup says to set the `X-Scheme` header but this is not respected because the corresponding flag is not set when instantiating `tornado.httpserver.HTTPServer`. This makes it impossible to terminate TLS on a reverse proxy.