### PR TITLE
Correctly sort History columns

### DIFF
--- a/samples/scripts/test.sh
+++ b/samples/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $@

--- a/samples/scripts/test.sh
+++ b/samples/scripts/test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo $@

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -60,15 +60,28 @@ export default {
       }
 
       let ascending = this.ascending;
+      let column = this.sortColumn;
 
-      this.rows.sort(function(a, b) {
-        if (a[sortKey] > b[sortKey]) {
-          return ascending ? 1 : -1
-        } else if (a[sortKey] < b[sortKey]) {
-          return ascending ? -1 : 1
+      this.rows.sort((a, b) => {
+        if (column === 'id') {
+          let id_a = a[sortKey];
+          let id_b = b[sortKey];
+          return ascending ? id_a - id_b : id_b - id_a
+
+        } else if (column === 'startTimeString') {
+          let date_a = new Date(a[sortKey]);
+          let date_b = new Date(b[sortKey]);
+          return ascending ? date_a - date_b : date_b - date_a
+
+        } else {
+          if (a[sortKey] > b[sortKey]) {
+            return ascending ? 1 : -1
+          } else if (a[sortKey] < b[sortKey]) {
+            return ascending ? -1 : 1
+          }
+          return 0;
         }
-        return 0;
-      })
+      });
     }
   },
 

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -74,9 +74,11 @@ export default {
           return ascending ? date_a - date_b : date_b - date_a
 
         } else {
-          if (a[sortKey] > b[sortKey]) {
+          let other_a = a[sortKey].toLowerCase()
+          let other_b = b[sortKey].toLowerCase()
+          if (other_a > other_b) {
             return ascending ? 1 : -1
-          } else if (a[sortKey] < b[sortKey]) {
+          } else if (other_a < other_b) {
             return ascending ? -1 : 1
           }
           return 0;


### PR DESCRIPTION
Sorting history columns introduced in https://github.com/bugy/script-server/pull/430 does not take into account that by default, `sort()` method sorts elements alphabetically. This leads to an unwanted sort result of: `[1, 10, 100, 2, 3]`

This PR enhances sorting to sort numerically, by date property etc.


