### PR TITLE
Feature: history search#572

### DIFF
--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -200,28 +200,9 @@ export default {
 
 .search-panel {
   display: flex;
-  padding: 5px;
-  border:  1px solid var(--primary-color);
-  border-radius: 4px;
-  background-color: var(--background-color-high-emphasis);
 }
 
 .search-button {
   align-self: center;
-}
-
-input.search-field {
-  height: 1.5rem;
-  font-size: 1rem;
-  float: right;
-  padding: 0;
-  margin: 0;
-  border: 0;
-  box-shadow: none;
-}
-
-input.search-field:not([type]):focus {
-  border-bottom: 0;
-  box-shadow: none;
 }
 </style>

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -38,25 +38,13 @@
 
 <script>
 import {mapState} from 'vuex';
-import SearchPanel from '../../../main-app/components/SearchPanel'
 import ClearIcon from '@/assets/clear.png'
 import SearchIcon from '@/assets/search.png'
 
 export default {
   name: 'executions-log-table',
-  components: {
-    SearchPanel
-  },
   props: {
     rows: Array,
-    'sortColumn': {
-      type: String,
-      default: 'id'
-    },
-    'ascending': {
-      type: Boolean,
-      default: false
-    },
     rowClick: {
       type: Function
     }
@@ -65,24 +53,24 @@ export default {
   data() {
     return {
       searchText: '',
-      mySortColumn: this.sortColumn,
-      myAscending: this.ascending
+      sortColumn: 'id',
+      ascending: false
     }
   },
 
   methods: {
     showSort: function (sortKey) {
-      if (this.mySortColumn === sortKey) {
-        return this.myAscending ? 'sorted asc' : 'sorted desc'
+      if (this.sortColumn === sortKey) {
+        return this.ascending ? 'sorted asc' : 'sorted desc'
       }
     },
 
     sortBy: function (sortKey) {
-      if (this.mySortColumn === sortKey) {
-        this.myAscending = !this.myAscending;
+      if (this.sortColumn === sortKey) {
+        this.ascending = !this.ascending;
       } else {
-        this.myAscending = true;
-        this.mySortColumn = sortKey;
+        this.ascending = true;
+        this.sortColumn = sortKey;
       }
     },
 
@@ -118,8 +106,8 @@ export default {
         });
       }
 
-      let ascending = this.myAscending;
-      let column = this.mySortColumn;
+      let ascending = this.ascending;
+      let column = this.sortColumn;
 
       return resultRows.sort((a, b) => {
         if (column === 'id') {

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -64,23 +64,9 @@ export default {
 
   data() {
     return {
-      filteredRows: this.rows ? [...this.rows] : [],
       searchText: '',
       mySortColumn: this.sortColumn,
       myAscending: this.ascending
-    }
-  },
-
-  watch: {
-    rows: function(val, oldVal) {
-      this.searchText = '';
-      this.filterRows();
-      this.sort();
-    },
-
-    searchText: function(val, oldVal) {
-      this.filterRows();
-      this.sort();
     }
   },
 
@@ -92,21 +78,50 @@ export default {
     },
 
     sortBy: function (sortKey) {
-      if (this.sortColumn === sortKey) {
+      if (this.mySortColumn === sortKey) {
         this.myAscending = !this.myAscending;
       } else {
         this.myAscending = true;
-        this.sortColumn = sortKey;
+        this.mySortColumn = sortKey;
       }
-
-      this.sort();
     },
 
-    sort: function() {
-      let ascending = this.myAscending;
-      let column = this.sortColumn;
+    searchIconClickHandler() {
+      if (this.isClearSearchButton) {
+        this.searchText = '';
+      }
+    },
+  },
 
-      this.filteredRows.sort((a, b) => {
+  computed: {
+    ...mapState('history', ['loading']),
+
+    isClearSearchButton() {
+      return this.searchText !== '';
+    },
+
+    searchImage() {
+      return this.isClearSearchButton ? ClearIcon : SearchIcon;
+    },
+
+    filteredRows() {
+      let searchText = (this.searchText || '').trim().toLowerCase();
+      let resultRows;
+      if(!this.rows) {
+        resultRows = [];
+      } else if(searchText === '') {
+        resultRows = [...this.rows];
+      } else {
+        resultRows = this.rows.filter((row) => {
+          return row.script.toLowerCase().includes(searchText) ||
+            row.user.toLowerCase().includes(searchText);
+        });
+      }
+
+      let ascending = this.myAscending;
+      let column = this.mySortColumn;
+
+      return resultRows.sort((a, b) => {
         if (column === 'id') {
           let id_a = a[column];
           let id_b = b[column];
@@ -128,42 +143,6 @@ export default {
           return 0;
         }
       });
-    },
-
-    filterRows: function() {
-      let searchText = (this.searchText || '').toLowerCase();
-
-      if(this.rows === null) {
-        this.filteredRows = [];
-        return;
-      }
-
-      if(searchText === '') {
-        this.filteredRows = [...this.rows];
-      } else {
-        this.filteredRows = this.rows.filter((row) => {
-          return row.script.toLowerCase().includes(searchText) ||
-            row.user.toLowerCase().includes(searchText);
-        });
-      }
-    },
-
-    searchIconClickHandler() {
-      if (this.isClearSearchButton) {
-        this.searchText = '';
-      }
-    },
-  },
-
-  computed: {
-    ...mapState('history', ['loading']),
-
-    isClearSearchButton() {
-      return this.searchText !== '';
-    },
-
-    searchImage() {
-      return this.isClearSearchButton ? ClearIcon : SearchIcon;
     }
   }
 }

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -65,7 +65,9 @@ export default {
   data() {
     return {
       filteredRows: this.rows ? [...this.rows] : [],
-      searchText: ''
+      searchText: '',
+      mySortColumn: this.sortColumn,
+      myAscending: this.ascending
     }
   },
 
@@ -84,16 +86,16 @@ export default {
 
   methods: {
     showSort: function (sortKey) {
-      if (this.sortColumn === sortKey) {
-        return this.ascending ? 'sorted asc' : 'sorted desc'
+      if (this.mySortColumn === sortKey) {
+        return this.myAscending ? 'sorted asc' : 'sorted desc'
       }
     },
 
     sortBy: function (sortKey) {
       if (this.sortColumn === sortKey) {
-        this.ascending = !this.ascending;
+        this.myAscending = !this.myAscending;
       } else {
-        this.ascending = true;
+        this.myAscending = true;
         this.sortColumn = sortKey;
       }
 
@@ -101,7 +103,7 @@ export default {
     },
 
     sort: function() {
-      let ascending = this.ascending;
+      let ascending = this.myAscending;
       let column = this.sortColumn;
 
       this.filteredRows.sort((a, b) => {

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -75,9 +75,12 @@ export default {
     },
 
     searchIconClickHandler() {
-      if (this.isClearSearchButton) {
+      if (this.searchText !== '') {
         this.searchText = '';
       }
+      this.$nextTick(() => {
+        this.$refs.searchField.focus();
+      });
     },
   },
 


### PR DESCRIPTION
A very simple implementation of search functionality in history. Search is implemented client-side. This currently searches only on 'user' and 'script' for the given search text. Suggestions are welcome.

Also fixed vue warning regarding mutating props. See commit - cdf8352891251e448b1858eaab0de8a62d608476

@bugy Need input on where to add this in documentation.

Note: I did not use the current 'SearchPanel' component, since it seemed very specific to the script search.
<img width="1128" alt="Screenshot 2022-10-06 at 12 28 24 PM" src="https://user-images.githubusercontent.com/1894828/194235265-70de4152-15b7-459b-acad-6b27b2434595.png">
<img width="1141" alt="Screenshot 2022-10-06 at 12 28 36 PM" src="https://user-images.githubusercontent.com/1894828/194235291-54527a59-be96-4da8-b980-f0d62746ed9d.png">
