### PR TITLE
#588 load_runner_files now returns [] in case of non-exisitent runners folder

### DIFF
--- a/src/migrations/migrate.py
+++ b/src/migrations/migrate.py
@@ -336,7 +336,7 @@ def _load_runner_files(conf_folder):
     runners_folder = os.path.join(conf_folder, 'runners')
 
     if not os.path.exists(runners_folder):
-        return
+        return []
 
     conf_files = [os.path.join(runners_folder, file)
                   for file in os.listdir(runners_folder)


### PR DESCRIPTION
fixes #588 