### PR TITLE
Exclude hidden folders when walking through script definitions

### DIFF
--- a/src/config/config_service.py
+++ b/src/config/config_service.py
@@ -262,9 +262,17 @@ class ConfigService:
     def _visit_script_configs(self, visitor):
         configs_dir = self._script_configs_folder
 
+        # We will ignore folders with this prefixes (ie: hidden folders)
+        exclude_prefixes=('.')
+
         files = []
         # Read config file from within directories too
         for _root, _dirs, _files in os.walk(configs_dir, topdown=True):
+            # In place exlustion of _dirs with exlusion prefixes
+            _dirs[:] = [_dirs
+                       for _dirs in _dirs
+                       if not _dirs.startswith(exclude_prefixes)]
+                       
             for name in _files:
                 files.append(os.path.join(_root, name))
 


### PR DESCRIPTION
Ignore hidden folders when through script definition folders.

Resolved issue: https://github.com/bugy/script-server/issues/696

I'm not sure if script definition form page permit to put definitions in a subfolders. My tests seem to show no. 
If this is still the case, maybe we should add a path validation in the form to avoir hidden folders.