### PR TITLE
fix: SyntaxWarning: invalid escape sequence

### DIFF
--- a/src/execution/logging.py
+++ b/src/execution/logging.py
@@ -289,7 +289,7 @@ class ExecutionLoggingService:
 
         parameters = {}
         for line in parameters_text.splitlines(keepends=True):
-            match = re.fullmatch('([\w_]+):(.*\r?\n)', line)
+            match = re.fullmatch(r'([\w_]+):(.*\r?\n)', line)
             if not match:
                 current_value += line
                 continue

--- a/src/migrations/migrate.py
+++ b/src/migrations/migrate.py
@@ -322,7 +322,7 @@ def __migrate_repeat_param_and_same_arg_param(context):
 
 
 def _write_json(file_path, json_object, old_content):
-    space_matches = re.findall('^\s+', old_content, flags=re.MULTILINE)
+    space_matches = re.findall(r'^\s+', old_content, flags=re.MULTILINE)
     if space_matches:
         indent_string = space_matches[0].replace('\t', '    ')
         indent = min(len(indent_string), 8)


### PR DESCRIPTION
Hi,
Despite https://github.com/bugy/script-server/issues/759 there is still 2 fix missing.
When starting script-server in python:3.13-bookworm docker image:
```
/tmp/script-server/src/migrations/migrate.py:325: SyntaxWarning: invalid escape sequence '\s'
  space_matches = re.findall('^\s+', old_content, flags=re.MULTILINE)
/tmp/script-server/src/execution/logging.py:292: SyntaxWarning: invalid escape sequence '\w'
  match = re.fullmatch('([\w_]+):(.*\r?\n)', line)
2025-01-13 15:25:37,634 [root.INFO] Starting Script Server (custom version)
2025-01-13 15:25:37,636 [asyncio.DEBUG] Using selector: EpollSelector
Server is running on: http://0.0.0.0:5000
```
This PR fix these 2 files