### PR TITLE
chore: add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "script-server"
+description = "Web UI for your scripts with execution management"
+version = "1.18.0"
+authors = []
+maintainers = []
+readme = "README.md"
+license-files = ["LICENSE"]
+
+requires-python = ">=3.7"
+dependencies = [
+  "tornado (>=5, <=7)",
+]
+
+[project.urls]
+Repository = "https://github.com/bugy/script-server"
+
+[project.scripts]
+script-server = "main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 
 requires-python = ">=3.7"
 dependencies = [
-  "tornado (>=5, <=7)",
+  "tornado (>=5, <7)",
 ]
 
 [project.urls]


### PR DESCRIPTION
First of all, thank you very much for this excellent project!

In the course of packaging up the script-server for NixOS, @tfc recommended to provide a `pyproject.toml` file to modernize the project a little, see [pyproject](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/). This is what we did in this PR.

If you would like to see the script-server on NixOS, the next PR we could do would be to package up the script-server in Nix and provide a NixOS module for it. Under NixOS, this will allow to install the script-server by simply doing ...

```nix
script-server.enable = true;
```

It will also allow to generate all kinds of images with script-server preinstalled, like an lxc container, Proxmox image, Azure image, etc. with a single Nix command.

Would you be interested in such a PR as well?