### PR TITLE
feat: make `web` folder configurable

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -30,10 +30,12 @@ parser.add_argument('-d', '--config-dir', default='conf')
 parser.add_argument('-f', '--config-file', default='conf.json')
 parser.add_argument('-l', '--log-folder', default='logs')
 parser.add_argument('-t', '--tmp-folder', default='temp')
+parser.add_argument('-w', '--web-folder', default='web')
 args = vars(parser.parse_args())
 
 TEMP_FOLDER = args['tmp_folder']
 LOG_FOLDER = args['log_folder']
+WEB_FOLDER = args['web_folder']
 
 CONFIG_FOLDER = args['config_dir']
 if os.path.isabs(args['config_file']):
@@ -59,7 +61,7 @@ def main():
     project_path = os.getcwd()
 
     try:
-        tool_utils.validate_web_build_exists(project_path)
+        tool_utils.validate_web_build_exists(WEB_FOLDER)
     except InvalidWebBuildException as e:
         print(str(e))
         sys.exit(-1)

--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,7 @@ def main():
     project_path = os.getcwd()
 
     try:
-        tool_utils.validate_web_build_exists(WEB_FOLDER)
+        tool_utils.validate_web_build_exists(os.path.realpath(WEB_FOLDER))
     except InvalidWebBuildException as e:
         print(str(e))
         sys.exit(-1)

--- a/src/utils/tool_utils.py
+++ b/src/utils/tool_utils.py
@@ -3,9 +3,7 @@ import os
 from utils import file_utils
 
 
-def validate_web_build_exists(project_path):
-    web_folder = os.path.join(project_path, 'web')
-
+def validate_web_build_exists(web_folder):
     how_to_fix_build_message = \
         'How to fix: ' \
         '\n - PROD: please use stable releases from https://github.com/bugy/script-server/releases/latest' \


### PR DESCRIPTION
This PR adds a parameter to make the `web` folder configurable. This has a few benefits, one is that we can easily experiment with different web roots. If I didn't overlook something, not using the parameter (which defaults to "web") should keep the current behavior.

Note: This PR is mainly based on https://github.com/tfc/script-server.