### PR TITLE
build: Add Nix/NixOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ web-src/geckodriver.log
 venv/
 /venv2/
 e2e_venv/
+
+# Nix / NixOS
+/result
+/*.qcow2

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780145889,
+        "narHash": "sha256-md0zn0RnwNvPyASas1yG5YUuwQ4ALA6ucL50l0DvqCo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Script-server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/26.05";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = {
+        overlays.default = final: prev: {
+          script-server = final.python3Packages.callPackage ./nix/package.nix { };
+
+          script-server-dist = final.callPackage ./nix/package-dist.nix { };
+        };
+
+        nixosModules.default = import ./nix/module.nix;
+      };
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { pkgs, ... }:
+        {
+          packages = {
+            script-server = pkgs.python3Packages.callPackage ./nix/package.nix { };
+
+            script-server-dist = pkgs.callPackage ./nix/package-dist.nix { };
+          };
+
+          formatter = pkgs.nixfmt-tree;
+        };
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.script-server;
+  json = pkgs.formats.json { };
+in
+{
+  options.services.script-server = {
+    enable = lib.mkEnableOption "Whether to enable script-server.";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.script-server;
+      description = "Script-server package to use.";
+    };
+
+    package-dist = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.script-server-dist;
+      description = "Script-server-dist package to use.";
+    };
+
+    settings = lib.mkOption {
+      type = json.type;
+      default = { };
+      description = "Server configuration, see <https://github.com/bugy/script-server/wiki/Server-configuration>.";
+    };
+
+    configuration = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/script-server/conf";
+      description = "Script configuration, see <https://github.com/bugy/script-server/wiki/Script-config>.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."script-server/conf.json".source =
+      json.generate "script-server-config" cfg.settings;
+
+    # See <https://github.com/bugy/script-server/wiki/Running-as-a-linux-service#systemd>
+    systemd.services.script-server = {
+      enable = true;
+
+      description = "Script Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Restart = "always";
+        RestartSec = "1s";
+        ExecStart = ''
+          ${cfg.package}/bin/script-server \
+            --config-file /etc/script-server/conf.json \
+            --config-dir ${cfg.configuration} \
+            --log-folder /var/log/script-server \
+            --tmp-folder /tmp
+        '';
+
+        # `main.py` expects `web` to be in working directory.
+        WorkingDirectory = "${cfg.package-dist}";
+        StateDirectory = "script-server";
+        LogsDirectory = "script-server";
+
+        DynamicUser = true;
+        PrivateTmp = true;
+      };
+    };
+  };
+}

--- a/nix/package-dist.nix
+++ b/nix/package-dist.nix
@@ -1,0 +1,23 @@
+{ lib, buildNpmPackage }:
+let
+  version = "1.18.0";
+in
+buildNpmPackage {
+  pname = "script-server-dist";
+  inherit version;
+
+  src = ../web-src;
+
+  npmDepsHash = "sha256-aBZDh2NcDU4OpsdTS8JqwGMa8WeIoyW9I6bUwTXfllU=";
+
+  makeCacheWritable = true;
+
+  # See <https://stackoverflow.com/questions/75959563/node-js-err-ossl-evp-unsupported-error-when-running-npm-run-start>
+  NODE_OPTIONS = "--openssl-legacy-provider";
+
+  installPhase = ''
+    mkdir "$out"
+    echo '${version}' > "$out/version.txt"
+    cp -r ../web "$out"
+  '';
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,30 @@
+let
+  toml = builtins.fromTOML (builtins.readFile ./../pyproject.toml);
+in
+{
+  lib,
+  buildPythonPackage,
+  tornado,
+  setuptools,
+}:
+buildPythonPackage {
+  pname = toml.project.name;
+  version = toml.project.version;
+  pyproject = true;
+
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ./../pyproject.toml
+      ./../src
+    ];
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    tornado
+  ];
+}


### PR DESCRIPTION
Hello, and sorry for the delay!

Here comes the first version (where I avoided [depending on a configurable `web` folder](https://github.com/bugy/script-server/pull/821).) I've added a few comments inline.

# Why do we want it?

## NixOS integration

With the files in place, NixOS users can (basically) add ...

```nix
services.script-server.enable = true;
```

... to their NixOS configuration and get a fully configured (systemd) script-server.

## Linux VM demo

With the files in place, Nix users can start a live qemu VM demo with script-server preconfigured via ...

```nix
nix run .#demo
```

## Linux image creation

With the files in place, Nix users can create {qemu,lxc,oci,...} images with script-server preinstalled and preconfigured by running ...

```nix
nix run .#nixosConfigurations.demo.config.system.build.images.<variant>
```

Especially LXC containers could make a lot of sense since they can be run natively on Proxmox.
<details>

<summary>Full list of supported images</summary>

```text
nixosConfigurations.demo.config.system.build.images.amazon              nixosConfigurations.demo.config.system.build.images.kubevirt            nixosConfigurations.demo.config.system.build.images.qemu
nixosConfigurations.demo.config.system.build.images.azure               nixosConfigurations.demo.config.system.build.images.linode              nixosConfigurations.demo.config.system.build.images.qemu-efi
nixosConfigurations.demo.config.system.build.images.cloudstack          nixosConfigurations.demo.config.system.build.images.lxc                 nixosConfigurations.demo.config.system.build.images.raw
nixosConfigurations.demo.config.system.build.images.digital-ocean       nixosConfigurations.demo.config.system.build.images.lxc-metadata        nixosConfigurations.demo.config.system.build.images.raw-efi
nixosConfigurations.demo.config.system.build.images.google-compute      nixosConfigurations.demo.config.system.build.images.oci                 nixosConfigurations.demo.config.system.build.images.sd-card
nixosConfigurations.demo.config.system.build.images.hyperv              nixosConfigurations.demo.config.system.build.images.openstack           nixosConfigurations.demo.config.system.build.images.vagrant-virtualbox
nixosConfigurations.demo.config.system.build.images.iso                 nixosConfigurations.demo.config.system.build.images.openstack-zfs       nixosConfigurations.demo.config.system.build.images.virtualbox
nixosConfigurations.demo.config.system.build.images.iso-installer       nixosConfigurations.demo.config.system.build.images.proxmox             nixosConfigurations.demo.config.system.build.images.vmware
nixosConfigurations.demo.config.system.build.images.kexec               nixosConfigurations.demo.config.system.build.images.proxmox-lxc
```
</details>

## NixOS test integration

With the files in place (and a little more effort), we could provide end-to-end integration tests where we automatically spawn a script-server via qemu and run all kinds of integration tests.