### PR TITLE
Add pagination to history and admin logs

### DIFF
--- a/src/execution/logging.py
+++ b/src/execution/logging.py
@@ -117,6 +117,7 @@ class ExecutionLoggingService:
 
         self._visited_files = set()
         self._ids_to_file_map = {}
+        self._entries_cache = {}
         self._output_loggers = {}
 
         file_utils.prepare_folder(output_folder)
@@ -183,33 +184,34 @@ class ExecutionLoggingService:
 
         log_file_path = os.path.join(self._output_folder, filename)
 
-        logger.set_close_callback(lambda: self._write_post_execution_info(log_file_path, exit_code))
+        def close_cb():
+            self._write_post_execution_info(log_file_path, exit_code)
+            cached_entry = self._entries_cache.get(execution_id)
+            if cached_entry:
+                cached_entry.exit_code = int(exit_code)
+
+        logger.set_close_callback(close_cb)
 
     def get_history_entries(self, user_id, *, system_call=False):
         self._renew_files_cache()
 
         result = []
 
-        for file in self._ids_to_file_map.values():
-            history_entry = self._extract_history_entry(file)
-            if history_entry is not None and self._can_access_entry(history_entry, user_id, system_call):
-                result.append(history_entry)
+        for entry in self._entries_cache.values():
+            if entry is not None and self._can_access_entry(entry, user_id, system_call):
+                result.append(entry)
 
         return result
 
     def find_history_entry(self, execution_id, user_id):
         self._renew_files_cache()
 
-        file = self._ids_to_file_map.get(execution_id)
-        if file is None:
+        entry = self._entries_cache.get(execution_id)
+        if entry is None:
             LOGGER.warning('find_history_entry: file for %s id not found', execution_id)
             return None
 
-        entry = self._extract_history_entry(file)
-        if entry is None:
-            LOGGER.warning('find_history_entry: cannot parse file for %s', execution_id)
-
-        elif not self._can_access_entry(entry, user_id):
+        if not self._can_access_entry(entry, user_id):
             message = 'User ' + user_id + ' has no access to execution #' + str(execution_id)
             LOGGER.warning('%s. Original user: %s', message, entry.user_id)
             raise AccessProhibitedException(message)
@@ -261,6 +263,7 @@ class ExecutionLoggingService:
         for obsolete_id in obsolete_ids:
             LOGGER.info('Logs for execution #' + obsolete_id + ' were deleted')
             del cache[obsolete_id]
+            self._entries_cache.pop(obsolete_id, None)
 
         for file in os.listdir(self._output_folder):
             if not file.lower().endswith('.log'):
@@ -276,6 +279,7 @@ class ExecutionLoggingService:
                 continue
 
             cache[entry.id] = file
+            self._entries_cache[entry.id] = entry
 
     @staticmethod
     def _create_log_identifier(audit_name, script_name, start_time):

--- a/src/tests/web/server_test.py
+++ b/src/tests/web/server_test.py
@@ -313,6 +313,98 @@ class ServerTest(TestCase):
         self._admin_session.cookies['username'] = create_signed_value(cookie_secret, 'username', 'admin_user') \
             .decode('utf8')
 
+    def _create_mock_history_entry(self, entry_id, user_name='normal_user', script_name='script1', start_time_ms=None, exit_code=0):
+        from execution.logging import HistoryEntry
+        from datetime import datetime, timezone
+        entry = HistoryEntry()
+        entry.id = str(entry_id)
+        entry.user_name = user_name
+        entry.user_id = user_name
+        entry.script_name = script_name
+        entry.command = 'python script.py'
+        entry.output_format = 'terminal'
+        entry.exit_code = exit_code
+        if start_time_ms is not None:
+            entry.start_time = datetime.fromtimestamp(start_time_ms / 1000.0, tz=timezone.utc)
+        return entry
+
+    def test_history_short_log_pagination_empty(self):
+        self.start_server(12345, '127.0.0.1')
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = []
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=25')
+        self.assertEqual(response, {
+            'records': [],
+            'total': 0,
+            'page': 1,
+            'pageSize': 25,
+            'totalPages': 1
+        })
+
+    def test_history_short_log_pagination_slicing_and_sorting(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [
+            self._create_mock_history_entry('e1', start_time_ms=1000),
+            self._create_mock_history_entry('e2', start_time_ms=3000),
+            self._create_mock_history_entry('e3', start_time_ms=2000),
+        ]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+
+        page1 = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=10')
+        self.assertEqual(page1['total'], 3)
+        self.assertEqual(page1['page'], 1)
+        self.assertEqual(page1['pageSize'], 10)
+        self.assertEqual(page1['totalPages'], 1)
+        self.assertEqual([r['id'] for r in page1['records']], ['e2', 'e3', 'e1'])
+
+    def test_history_short_log_pagination_multiple_pages(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [self._create_mock_history_entry(f'e{i}', start_time_ms=i * 1000) for i in range(1, 35)]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+
+        res_p1 = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=10')
+        self.assertEqual(res_p1['total'], 34)
+        self.assertEqual(res_p1['page'], 1)
+        self.assertEqual(res_p1['pageSize'], 10)
+        self.assertEqual(res_p1['totalPages'], 4)
+        self.assertEqual(len(res_p1['records']), 10)
+        self.assertEqual(res_p1['records'][0]['id'], 'e34')
+
+        res_p4 = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=4&size=10')
+        self.assertEqual(res_p4['page'], 4)
+        self.assertEqual(len(res_p4['records']), 4)
+        self.assertEqual(res_p4['records'][-1]['id'], 'e1')
+
+    def test_history_short_log_pagination_invalid_size_fallback(self):
+        self.start_server(12345, '127.0.0.1')
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = []
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=999')
+        self.assertEqual(response['pageSize'], 25)
+
+        response_abc = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=abc')
+        self.assertEqual(response_abc['pageSize'], 25)
+
+    def test_history_short_log_pagination_invalid_page_fallback(self):
+        self.start_server(12345, '127.0.0.1')
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = []
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=-5&size=25')
+        self.assertEqual(response['page'], 1)
+
+        response_invalid = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=xyz&size=25')
+        self.assertEqual(response_invalid['page'], 1)
+
+    def test_history_short_log_legacy_unpaginated(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [self._create_mock_history_entry('e1', start_time_ms=1000)]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short')
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]['id'], 'e1')
+
     def start_loop(self):
         io_loop = IOLoop.current()
         self.ioloop_thread = threading.Thread(target=io_loop.start)

--- a/src/tests/web/server_test.py
+++ b/src/tests/web/server_test.py
@@ -450,6 +450,37 @@ class ServerTest(TestCase):
         self.assertEqual(records[1]['id'], 'finished_1')
         self.assertEqual(records[1]['status'], 'finished')
 
+    def test_isolated_paginate_empty(self):
+        result = server.paginate_history_entries([], '1', '25')
+        self.assertEqual(result, {
+            'records': [],
+            'total': 0,
+            'page': 1,
+            'pageSize': 25,
+            'totalPages': 1
+        })
+
+    def test_isolated_paginate_legacy_unpaginated_returns_list(self):
+        entries = [self._create_mock_history_entry('e1', start_time_ms=1000)]
+        result = server.paginate_history_entries(entries, None, None)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+
+    def test_isolated_paginate_running_checker_only_called_for_sliced_page(self):
+        entries = [self._create_mock_history_entry(f'e{i}', start_time_ms=i * 1000) for i in range(1, 100)]
+        checked_ids = []
+
+        def mock_checker(entry_id):
+            checked_ids.append(entry_id)
+            return entry_id == 'e99'
+
+        result = server.paginate_history_entries(entries, '1', '10', is_running_checker=mock_checker)
+        self.assertEqual(result['total'], 99)
+        self.assertEqual(result['page'], 1)
+        self.assertEqual(len(result['records']), 10)
+        self.assertEqual(len(checked_ids), 10)
+        self.assertEqual(checked_ids[0], 'e99')
+
     def start_loop(self):
         io_loop = IOLoop.current()
         self.ioloop_thread = threading.Thread(target=io_loop.start)

--- a/src/tests/web/server_test.py
+++ b/src/tests/web/server_test.py
@@ -405,6 +405,51 @@ class ServerTest(TestCase):
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]['id'], 'e1')
 
+    def test_history_short_log_pagination_page_out_of_bounds(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [self._create_mock_history_entry(f'e{i}', start_time_ms=i * 1000) for i in range(1, 31)]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=99&size=10')
+        self.assertEqual(response['page'], 3)
+        self.assertEqual(response['totalPages'], 3)
+        self.assertEqual(len(response['records']), 10)
+
+    def test_history_short_log_pagination_with_none_start_time(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [
+            self._create_mock_history_entry('e_none', start_time_ms=None),
+            self._create_mock_history_entry('e_valid', start_time_ms=5000)
+        ]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=10')
+        self.assertEqual([r['id'] for r in response['records']], ['e_valid', 'e_none'])
+
+    def test_history_short_log_pagination_all_supported_sizes(self):
+        self.start_server(12345, '127.0.0.1')
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = []
+
+        for size in [10, 25, 50, 100, 250, 500]:
+            response = self.request('GET', f'http://127.0.0.1:12345/history/execution_log/short?page=1&size={size}')
+            self.assertEqual(response['pageSize'], size)
+
+    def test_history_short_log_pagination_running_script_status(self):
+        self.start_server(12345, '127.0.0.1')
+        entries = [
+            self._create_mock_history_entry('running_1', start_time_ms=2000, exit_code=None),
+            self._create_mock_history_entry('finished_1', start_time_ms=1000, exit_code=0)
+        ]
+        server._tornado_app.execution_logging_service.get_history_entries.return_value = entries
+        server._tornado_app.execution_service.is_running.side_effect = lambda entry_id, user: entry_id == 'running_1'
+
+        response = self.request('GET', 'http://127.0.0.1:12345/history/execution_log/short?page=1&size=10')
+        records = response['records']
+        self.assertEqual(records[0]['id'], 'running_1')
+        self.assertEqual(records[0]['status'], 'running')
+        self.assertEqual(records[1]['id'], 'finished_1')
+        self.assertEqual(records[1]['status'], 'finished')
+
     def start_loop(self):
         io_loop = IOLoop.current()
         self.ioloop_thread = threading.Thread(target=io_loop.start)

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -2,11 +2,13 @@
 import asyncio
 import json
 import logging.config
+import math
 import os
 import signal
 import ssl
 import time
 import urllib
+from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 import tornado.concurrent
@@ -679,18 +681,76 @@ class ReceiveAlertHandler(BaseRequestHandler):
             file_utils.write_file(file_path, value)
 
 
+ALLOWED_PAGE_SIZES = {10, 25, 50, 100, 250, 500}
+DEFAULT_PAGE_SIZE = 25
+
+
 class GetShortHistoryEntriesHandler(BaseRequestHandler):
     @check_authorization
     @inject_user
     def get(self, user):
+        page_arg = self.get_argument('page', None)
+        size_arg = self.get_argument('size', None)
+
         history_entries = self.application.execution_logging_service.get_history_entries(user.user_id)
+
+        def _get_sort_key(entry):
+            if entry.start_time is None:
+                return datetime.min.replace(tzinfo=timezone.utc)
+            return entry.start_time
+
+        history_entries.sort(key=_get_sort_key, reverse=True)
+
+        if page_arg is None and size_arg is None:
+            running_script_ids = []
+            for entry in history_entries:
+                if self.application.execution_service.is_running(entry.id, user):
+                    running_script_ids.append(entry.id)
+
+            short_logs = to_short_execution_log(history_entries, running_script_ids)
+            self.write(json.dumps(short_logs))
+            return
+
+        try:
+            size = int(size_arg) if size_arg is not None else DEFAULT_PAGE_SIZE
+            if size not in ALLOWED_PAGE_SIZES:
+                size = DEFAULT_PAGE_SIZE
+        except (ValueError, TypeError):
+            size = DEFAULT_PAGE_SIZE
+
+        try:
+            page = int(page_arg) if page_arg is not None else 1
+            if page < 1:
+                page = 1
+        except (ValueError, TypeError):
+            page = 1
+
+        total_count = len(history_entries)
+        total_pages = math.ceil(total_count / size) if total_count > 0 else 1
+
+        if page > total_pages and total_pages > 0:
+            page = total_pages
+
+        start_idx = (page - 1) * size
+        end_idx = start_idx + size
+        page_entries = history_entries[start_idx:end_idx]
+
         running_script_ids = []
-        for entry in history_entries:
+        for entry in page_entries:
             if self.application.execution_service.is_running(entry.id, user):
                 running_script_ids.append(entry.id)
 
-        short_logs = to_short_execution_log(history_entries, running_script_ids)
-        self.write(json.dumps(short_logs))
+        short_logs = to_short_execution_log(page_entries, running_script_ids)
+
+        response = {
+            'records': short_logs,
+            'total': total_count,
+            'page': page,
+            'pageSize': size,
+            'totalPages': total_pages
+        }
+
+        self.write(json.dumps(response))
 
 
 class GetLongHistoryEntryHandler(BaseRequestHandler):
@@ -895,7 +955,8 @@ def init(server_config: ServerConfig,
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     io_loop = tornado.ioloop.IOLoop.current()
 
-    global _http_server
+    global _http_server, _tornado_app
+    _tornado_app = application
     _http_server = httpserver.HTTPServer(
         application,
         ssl_options=ssl_context,

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -685,6 +685,53 @@ ALLOWED_PAGE_SIZES = {10, 25, 50, 100, 250, 500}
 DEFAULT_PAGE_SIZE = 25
 
 
+def paginate_history_entries(entries, page_arg, size_arg, is_running_checker=None):
+    def _get_sort_key(entry):
+        if entry.start_time is None:
+            return datetime.min.replace(tzinfo=timezone.utc)
+        return entry.start_time
+
+    entries.sort(key=_get_sort_key, reverse=True)
+
+    if page_arg is None and size_arg is None:
+        running_ids = [e.id for e in entries if is_running_checker and is_running_checker(e.id)]
+        return to_short_execution_log(entries, running_ids)
+
+    try:
+        size = int(size_arg) if size_arg is not None else DEFAULT_PAGE_SIZE
+        if size not in ALLOWED_PAGE_SIZES:
+            size = DEFAULT_PAGE_SIZE
+    except (ValueError, TypeError):
+        size = DEFAULT_PAGE_SIZE
+
+    try:
+        page = int(page_arg) if page_arg is not None else 1
+        if page < 1:
+            page = 1
+    except (ValueError, TypeError):
+        page = 1
+
+    total_count = len(entries)
+    total_pages = math.ceil(total_count / size) if total_count > 0 else 1
+
+    if page > total_pages and total_pages > 0:
+        page = total_pages
+
+    start_idx = (page - 1) * size
+    end_idx = start_idx + size
+    page_entries = entries[start_idx:end_idx]
+
+    running_ids = [e.id for e in page_entries if is_running_checker and is_running_checker(e.id)]
+
+    return {
+        'records': to_short_execution_log(page_entries, running_ids),
+        'total': total_count,
+        'page': page,
+        'pageSize': size,
+        'totalPages': total_pages
+    }
+
+
 class GetShortHistoryEntriesHandler(BaseRequestHandler):
     @check_authorization
     @inject_user
@@ -694,63 +741,14 @@ class GetShortHistoryEntriesHandler(BaseRequestHandler):
 
         history_entries = self.application.execution_logging_service.get_history_entries(user.user_id)
 
-        def _get_sort_key(entry):
-            if entry.start_time is None:
-                return datetime.min.replace(tzinfo=timezone.utc)
-            return entry.start_time
+        result = paginate_history_entries(
+            history_entries,
+            page_arg,
+            size_arg,
+            is_running_checker=lambda entry_id: self.application.execution_service.is_running(entry_id, user)
+        )
 
-        history_entries.sort(key=_get_sort_key, reverse=True)
-
-        if page_arg is None and size_arg is None:
-            running_script_ids = []
-            for entry in history_entries:
-                if self.application.execution_service.is_running(entry.id, user):
-                    running_script_ids.append(entry.id)
-
-            short_logs = to_short_execution_log(history_entries, running_script_ids)
-            self.write(json.dumps(short_logs))
-            return
-
-        try:
-            size = int(size_arg) if size_arg is not None else DEFAULT_PAGE_SIZE
-            if size not in ALLOWED_PAGE_SIZES:
-                size = DEFAULT_PAGE_SIZE
-        except (ValueError, TypeError):
-            size = DEFAULT_PAGE_SIZE
-
-        try:
-            page = int(page_arg) if page_arg is not None else 1
-            if page < 1:
-                page = 1
-        except (ValueError, TypeError):
-            page = 1
-
-        total_count = len(history_entries)
-        total_pages = math.ceil(total_count / size) if total_count > 0 else 1
-
-        if page > total_pages and total_pages > 0:
-            page = total_pages
-
-        start_idx = (page - 1) * size
-        end_idx = start_idx + size
-        page_entries = history_entries[start_idx:end_idx]
-
-        running_script_ids = []
-        for entry in page_entries:
-            if self.application.execution_service.is_running(entry.id, user):
-                running_script_ids.append(entry.id)
-
-        short_logs = to_short_execution_log(page_entries, running_script_ids)
-
-        response = {
-            'records': short_logs,
-            'total': total_count,
-            'page': page,
-            'pageSize': size,
-            'totalPages': total_pages
-        }
-
-        self.write(json.dumps(response))
+        self.write(json.dumps(result))
 
 
 class GetLongHistoryEntryHandler(BaseRequestHandler):

--- a/web-src/src/common/components/history/Paginator.vue
+++ b/web-src/src/common/components/history/Paginator.vue
@@ -1,0 +1,208 @@
+<template>
+  <div class="paginator-container">
+    <div class="paginator-info-panel">
+      <label class="page-size-label">
+        <span>Per page:</span>
+        <select class="browser-default page-size-select" :value="pageSize" @change="onSizeChange" :disabled="disabled">
+          <option v-for="option in pageSizeOptions" :key="option" :value="option">
+            {{ option }}
+          </option>
+        </select>
+      </label>
+      <span class="records-info">{{ infoText }}</span>
+    </div>
+
+    <div class="paginator-controls">
+      <button class="btn-flat btn-pagination" :disabled="disabled || isFirstPage" @click="onFirst" title="First page">
+        «
+      </button>
+      <button class="btn-flat btn-pagination" :disabled="disabled || isFirstPage" @click="onPrev" title="Previous page">
+        ‹ Prev
+      </button>
+
+      <span class="page-indicator">
+        Page {{ page }} of {{ totalPages || 1 }}
+      </span>
+
+      <button class="btn-flat btn-pagination" :disabled="disabled || isLastPage" @click="onNext" title="Next page">
+        Next ›
+      </button>
+      <button class="btn-flat btn-pagination" :disabled="disabled || isLastPage" @click="onLast" title="Last page">
+        »
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Paginator',
+
+  props: {
+    page: {
+      type: Number,
+      default: 1
+    },
+    pageSize: {
+      type: Number,
+      default: 25
+    },
+    total: {
+      type: Number,
+      default: 0
+    },
+    totalPages: {
+      type: Number,
+      default: 1
+    },
+    pageSizeOptions: {
+      type: Array,
+      default: () => [10, 25, 50, 100, 250, 500]
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    startRecord() {
+      if (this.total === 0) return 0;
+      return (this.page - 1) * this.pageSize + 1;
+    },
+
+    endRecord() {
+      if (this.total === 0) return 0;
+      return Math.min(this.page * this.pageSize, this.total);
+    },
+
+    infoText() {
+      if (this.total === 0) {
+        return 'No entries';
+      }
+      return `Showing ${this.startRecord} - ${this.endRecord} of ${this.total} entries`;
+    },
+
+    isFirstPage() {
+      return this.page <= 1;
+    },
+
+    isLastPage() {
+      return this.page >= this.totalPages || this.totalPages === 0;
+    }
+  },
+
+  methods: {
+    onSizeChange(event) {
+      const newSize = parseInt(event.target.value, 10);
+      this.$emit('size-change', newSize);
+    },
+
+    onFirst() {
+      if (!this.isFirstPage) {
+        this.$emit('page-change', 1);
+      }
+    },
+
+    onPrev() {
+      if (!this.isFirstPage) {
+        this.$emit('page-change', this.page - 1);
+      }
+    },
+
+    onNext() {
+      if (!this.isLastPage) {
+        this.$emit('page-change', this.page + 1);
+      }
+    },
+
+    onLast() {
+      if (!this.isLastPage) {
+        this.$emit('page-change', this.totalPages);
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.paginator-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  margin-top: 1rem;
+  border-top: 1px solid var(--border-color, #e0e0e0);
+  font-size: 0.95rem;
+  color: var(--font-color-main, #333);
+}
+
+.paginator-info-panel {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.page-size-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--font-color-main, #333);
+  margin: 0;
+}
+
+.page-size-select {
+  display: inline-block;
+  width: auto;
+  height: 2rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 4px;
+  background-color: var(--background-color-secondary, #fff);
+  color: var(--font-color-main, #333);
+  cursor: pointer;
+}
+
+.records-info {
+  color: var(--font-color-medium, #666);
+}
+
+.paginator-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.btn-pagination {
+  padding: 0.3rem 0.7rem;
+  height: auto;
+  line-height: normal;
+  border-radius: 4px;
+  border: 1px solid var(--border-color, #ccc);
+  background-color: var(--background-color-secondary, #fff);
+  color: var(--font-color-main, #333);
+  cursor: pointer;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.btn-pagination:hover:not(:disabled) {
+  background-color: var(--primary-color-light, #e3f2fd);
+  border-color: var(--primary-color, #2196f3);
+  color: var(--primary-color, #2196f3);
+}
+
+.btn-pagination:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.page-indicator {
+  padding: 0 0.6rem;
+  font-weight: 500;
+  color: var(--font-color-main, #333);
+}
+</style>

--- a/web-src/src/common/components/history/Paginator.vue
+++ b/web-src/src/common/components/history/Paginator.vue
@@ -14,10 +14,10 @@
 
     <div class="paginator-controls">
       <button class="btn-flat btn-pagination" :disabled="disabled || isFirstPage" @click="onFirst" title="First page">
-        «
+        <svg viewBox="0 0 24 24" class="pagination-icon"><path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"/></svg>
       </button>
       <button class="btn-flat btn-pagination" :disabled="disabled || isFirstPage" @click="onPrev" title="Previous page">
-        ‹ Prev
+        <svg viewBox="0 0 24 24" class="pagination-icon"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
       </button>
 
       <span class="page-indicator">
@@ -25,10 +25,10 @@
       </span>
 
       <button class="btn-flat btn-pagination" :disabled="disabled || isLastPage" @click="onNext" title="Next page">
-        Next ›
+        <svg viewBox="0 0 24 24" class="pagination-icon"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
       </button>
       <button class="btn-flat btn-pagination" :disabled="disabled || isLastPage" @click="onLast" title="Last page">
-        »
+        <svg viewBox="0 0 24 24" class="pagination-icon"><path d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"/></svg>
       </button>
     </div>
   </div>
@@ -178,15 +178,24 @@ export default {
 }
 
 .btn-pagination {
-  padding: 0.3rem 0.7rem;
-  height: auto;
-  line-height: normal;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.5rem;
+  min-width: 2.2rem;
+  height: 2.2rem;
   border-radius: 4px;
   border: 1px solid var(--border-color, #ccc);
   background-color: var(--background-color-secondary, #fff);
   color: var(--font-color-main, #333);
   cursor: pointer;
-  transition: background-color 0.2s ease, opacity 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.pagination-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
 }
 
 .btn-pagination:hover:not(:disabled) {
@@ -196,7 +205,7 @@ export default {
 }
 
 .btn-pagination:disabled {
-  opacity: 0.4;
+  opacity: 0.35;
   cursor: not-allowed;
 }
 

--- a/web-src/src/common/components/history/executions-log-table.vue
+++ b/web-src/src/common/components/history/executions-log-table.vue
@@ -32,7 +32,8 @@
       </tr>
       </tbody>
     </table>
-    <p v-if="loading" class="loading-text">History will appear here</p>
+    <p v-if="loading" class="loading-text">Loading history...</p>
+    <p v-else-if="filteredRows.length === 0" class="empty-text">No entries found</p>
   </div>
 </template>
 
@@ -168,11 +169,13 @@ export default {
   width: 15%;
 }
 
-.loading-text {
+.loading-text,
+.empty-text {
   color: var(--font-color-medium);
   font-size: 1.2em;
   text-align: center;
-  margin-top: 1em;
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
 }
 
 .executions-log-table .sorted:after {

--- a/web-src/src/common/components/history/executions-log.vue
+++ b/web-src/src/common/components/history/executions-log.vue
@@ -1,14 +1,27 @@
 <template>
   <div class="container">
     <PageProgress v-if="loading && !disableProgressIndicator"/>
-    <executions-log-table v-else :rowClick="goToLog" :rows="executionRows"/>
+    <div v-else class="history-log-content">
+      <executions-log-table :rowClick="goToLog" :rows="executionRows"/>
+      <Paginator
+        :page="page"
+        :pageSize="pageSize"
+        :total="total"
+        :totalPages="totalPages"
+        :pageSizeOptions="pageSizeOptions"
+        :disabled="loading"
+        @page-change="onPageChange"
+        @size-change="onSizeChange"
+      />
+    </div>
   </div>
 </template>
 
 <script>
 import {mapActions, mapState} from 'vuex';
 import PageProgress from '../PageProgress';
-import ExecutionsLogTable from './executions-log-table'
+import ExecutionsLogTable from './executions-log-table';
+import Paginator from './Paginator';
 
 export default {
   name: 'executions-log',
@@ -21,7 +34,8 @@ export default {
   },
   components: {
     'executions-log-table': ExecutionsLogTable,
-    PageProgress
+    PageProgress,
+    Paginator
   },
 
   mounted: function () {
@@ -29,29 +43,45 @@ export default {
   },
 
   methods: {
-    ...mapActions('history', ['init']),
+    ...mapActions('history', ['init', 'changePage', 'changePageSize']),
 
     goToLog(execution_entry) {
       this.$router.push({
         path: this.$router.history.current.path + '/' + execution_entry.id
       });
+    },
+
+    onPageChange(newPage) {
+      this.changePage(newPage);
+    },
+
+    onSizeChange(newSize) {
+      this.changePageSize(newSize);
     }
   },
 
   computed: {
     ...mapState('history', {
       executionRows: 'executions',
-      loading: 'loading'
+      loading: 'loading',
+      page: 'page',
+      pageSize: 'pageSize',
+      total: 'total',
+      totalPages: 'totalPages',
+      pageSizeOptions: 'pageSizeOptions'
     })
   }
 }
-
-
 </script>
 
 <style scoped>
 div.executions-log {
   height: 100%;
+}
+
+.history-log-content {
+  display: flex;
+  flex-direction: column;
 }
 
 div.progress {

--- a/web-src/src/common/store/executions-module.js
+++ b/web-src/src/common/store/executions-module.js
@@ -7,21 +7,73 @@ const store = () => ({
         selectedExecution: null,
         selectedExecutionId: null,
         loading: false,
-        detailsLoading: false
+        detailsLoading: false,
+        page: 1,
+        pageSize: 25,
+        total: 0,
+        totalPages: 1,
+        pageSizeOptions: [10, 25, 50, 100, 250, 500]
     },
     namespaced: true,
     actions: {
-        init({commit}) {
+        init({dispatch}) {
+            return dispatch('loadExecutions');
+        },
+
+        loadExecutions({commit, state}, params = {}) {
             commit('SET_LOADING', true);
             commit('SET_EXECUTION_DETAILS', {execution: null, id: null});
 
-            axiosInstance.get('history/execution_log/short').then(({data}) => {
-                sortExecutionLogs(data);
+            const page = params.page !== undefined ? params.page : state.page;
+            const size = params.size !== undefined ? params.size : state.pageSize;
 
-                let executions = data.map(log => translateExecutionLog(log));
+            return axiosInstance.get('history/execution_log/short', {
+                params: {
+                    page,
+                    size
+                }
+            }).then(({data}) => {
+                let executions = [];
+                let paginationData = {};
+
+                if (Array.isArray(data)) {
+                    sortExecutionLogs(data);
+                    executions = data.map(log => translateExecutionLog(log));
+                    paginationData = {
+                        page: 1,
+                        pageSize: executions.length || size,
+                        total: executions.length,
+                        totalPages: 1
+                    };
+                } else if (data && typeof data === 'object') {
+                    let records = data.records || [];
+                    executions = records.map(log => translateExecutionLog(log));
+                    paginationData = {
+                        page: data.page || page,
+                        pageSize: data.pageSize || size,
+                        total: data.total || 0,
+                        totalPages: data.totalPages || 1
+                    };
+                }
+
                 commit('SET_EXECUTIONS', executions);
+                commit('SET_PAGINATION', paginationData);
                 commit('SET_LOADING', false);
+            }).catch((error) => {
+                commit('SET_LOADING', false);
+                logError(error);
             });
+        },
+
+        changePage({dispatch, state}, newPage) {
+            if (newPage < 1 || (state.totalPages > 0 && newPage > state.totalPages)) {
+                return;
+            }
+            return dispatch('loadExecutions', {page: newPage, size: state.pageSize});
+        },
+
+        changePageSize({dispatch}, newSize) {
+            return dispatch('loadExecutions', {page: 1, size: newSize});
         },
 
         selectExecution({commit, state}, executionId) {
@@ -63,6 +115,13 @@ const store = () => ({
 
         SET_EXECUTIONS(state, executions) {
             state.executions = executions;
+        },
+
+        SET_PAGINATION(state, {page, pageSize, total, totalPages}) {
+            if (page !== undefined) state.page = page;
+            if (pageSize !== undefined) state.pageSize = pageSize;
+            if (total !== undefined) state.total = total;
+            if (totalPages !== undefined) state.totalPages = totalPages;
         },
 
         SET_EXECUTION_DETAILS(state, {execution, id}) {

--- a/web-src/tests/unit/history/paginator_test.js
+++ b/web-src/tests/unit/history/paginator_test.js
@@ -1,0 +1,129 @@
+'use strict';
+import Paginator from '@/common/components/history/Paginator';
+import {mount} from '@vue/test-utils';
+import {createScriptServerTestVue} from '../test_utils';
+
+const localVue = createScriptServerTestVue();
+
+describe('Paginator.vue', function () {
+    let wrapper;
+
+    afterEach(function () {
+        if (wrapper) {
+            wrapper.destroy();
+        }
+    });
+
+    it('renders empty entries info when total is 0', function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 1,
+                pageSize: 25,
+                total: 0,
+                totalPages: 1
+            }
+        });
+
+        expect(wrapper.find('.records-info').text()).toBe('No entries');
+        expect(wrapper.find('.page-indicator').text()).toBe('Page 1 of 1');
+    });
+
+    it('renders correct records range info text', function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 2,
+                pageSize: 25,
+                total: 100,
+                totalPages: 4
+            }
+        });
+
+        expect(wrapper.find('.records-info').text()).toBe('Showing 26 - 50 of 100 entries');
+        expect(wrapper.find('.page-indicator').text()).toBe('Page 2 of 4');
+    });
+
+    it('disables first and prev buttons on page 1', function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 1,
+                pageSize: 25,
+                total: 50,
+                totalPages: 2
+            }
+        });
+
+        const buttons = wrapper.findAll('button');
+        const firstBtn = buttons.at(0);
+        const prevBtn = buttons.at(1);
+        const nextBtn = buttons.at(2);
+        const lastBtn = buttons.at(3);
+
+        expect(firstBtn.element.disabled).toBe(true);
+        expect(prevBtn.element.disabled).toBe(true);
+        expect(nextBtn.element.disabled).toBe(false);
+        expect(lastBtn.element.disabled).toBe(false);
+    });
+
+    it('disables next and last buttons on last page', function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 2,
+                pageSize: 25,
+                total: 50,
+                totalPages: 2
+            }
+        });
+
+        const buttons = wrapper.findAll('button');
+        const firstBtn = buttons.at(0);
+        const prevBtn = buttons.at(1);
+        const nextBtn = buttons.at(2);
+        const lastBtn = buttons.at(3);
+
+        expect(firstBtn.element.disabled).toBe(false);
+        expect(prevBtn.element.disabled).toBe(false);
+        expect(nextBtn.element.disabled).toBe(true);
+        expect(lastBtn.element.disabled).toBe(true);
+    });
+
+    it('emits page-change event when clicking next', async function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 1,
+                pageSize: 25,
+                total: 50,
+                totalPages: 2
+            }
+        });
+
+        const nextBtn = wrapper.findAll('button').at(2);
+        await nextBtn.trigger('click');
+
+        expect(wrapper.emitted('page-change')).toBeTruthy();
+        expect(wrapper.emitted('page-change')[0]).toEqual([2]);
+    });
+
+    it('emits size-change event when selecting new page size', async function () {
+        wrapper = mount(Paginator, {
+            localVue,
+            propsData: {
+                page: 1,
+                pageSize: 25,
+                total: 100,
+                totalPages: 4,
+                pageSizeOptions: [10, 25, 50, 100]
+            }
+        });
+
+        const select = wrapper.find('select');
+        await select.setValue('50');
+
+        expect(wrapper.emitted('size-change')).toBeTruthy();
+        expect(wrapper.emitted('size-change')[0]).toEqual([50]);
+    });
+});


### PR DESCRIPTION
I have added pagination to the "History" and "Logs" pages, as loading all entries at once was significantly slowing things down when there were many entries.

To improve performance, I also implemented an in-memory cache (`_entries_cache` in `logging.py`) so log files are parsed once on discovery and served directly from RAM without repeated disk reads.

I have tested this locally and added unit tests for both backend and frontend.

Key changes:
- Backend: Added pagination query params (`?page=X&size=Y`) and implemented RAM caching for logs. Optimized status checks to only run for active page entries.
- Frontend: Added a reusable Paginator component (10, 25, 50, 100, 250, 500 entries) and updated production build files.