### PR TITLE
[Breaking] Require a proxy secret before trusting the identity header in no-login mode

### DIFF
--- a/src/auth/identification.py
+++ b/src/auth/identification.py
@@ -1,4 +1,5 @@
 import abc
+import hmac
 import logging
 import uuid
 
@@ -34,14 +35,21 @@ class AuthBasedIdentification(Identification):
         return self.identify(request_handler)
 
 
+class InvalidUserHeaderSecretException(Exception):
+    def __init__(self, message) -> None:
+        super().__init__(message)
+
+
 class IpBasedIdentification(Identification):
     EXPIRES_DAYS = 14
     COOKIE_KEY = 'client_id_token'
     EMPTY_TOKEN = (None, None)
+    PROXY_SECRET_HEADER = 'X-ScriptServer-Proxy-Secret'
 
-    def __init__(self, ip_validator: TrustedIpValidator, user_header_name) -> None:
+    def __init__(self, ip_validator: TrustedIpValidator, user_header_name, user_header_secret=None) -> None:
         self._ip_validator = ip_validator
         self._user_header_name = user_header_name
+        self._user_header_secret = user_header_secret
 
     def identify(self, request_handler):
         remote_ip = request_handler.request.remote_ip
@@ -53,7 +61,16 @@ class IpBasedIdentification(Identification):
             if self._user_header_name:
                 user_header = request_handler.request.headers.get(self._user_header_name, None)
                 if user_header:
-                    return user_header
+                    if not self._user_header_secret:
+                        LOGGER.warning(
+                            'Client %s sent %s header but user_header_secret is not configured, '
+                            'ignoring the claimed identity. Configure user_header_secret to enable '
+                            'header-based identity.', remote_ip, self._user_header_name)
+                    elif not self._verify_user_header_secret(request_handler):
+                        raise InvalidUserHeaderSecretException(
+                            'Missing or invalid ' + self.PROXY_SECRET_HEADER + ' header')
+                    else:
+                        return user_header
             return self._resolve_ip(request_handler)
 
         (client_id, days_remaining) = self._read_client_token(request_handler)
@@ -77,9 +94,22 @@ class IpBasedIdentification(Identification):
 
     def identify_for_audit(self, request_handler):
         remote_ip = request_handler.request.remote_ip
-        if self._ip_validator.is_trusted(remote_ip) and (self._user_header_name):
-            return request_handler.request.headers.get(self._user_header_name, None)
+        if self._ip_validator.is_trusted(remote_ip) and self._user_header_name and self._user_header_secret:
+            user_header = request_handler.request.headers.get(self._user_header_name, None)
+            if user_header and self._verify_user_header_secret(request_handler):
+                return user_header
         return None
+
+    def _verify_user_header_secret(self, request_handler):
+        provided_secret = request_handler.request.headers.get(self.PROXY_SECRET_HEADER, None)
+        if provided_secret and hmac.compare_digest(
+                self._user_header_secret.encode('utf-8'),
+                provided_secret.encode('utf-8')):
+            return True
+
+        LOGGER.warning('Client %s sent %s header without a valid %s header, ignoring the claimed identity',
+                       request_handler.request.remote_ip, self._user_header_name, self.PROXY_SECRET_HEADER)
+        return False
 
     def _resolve_ip(self, request_handler):
         proxied_ip = tornado_utils.get_proxied_ip(request_handler)

--- a/src/model/server_conf.py
+++ b/src/model/server_conf.py
@@ -41,6 +41,7 @@ class ServerConfig(object):
         self.max_request_size_mb = None
         self.callbacks_config = None
         self.user_header_name = None
+        self.user_header_secret = None
         self.secret_storage_file = None
         self.xsrf_protection = None
         # noinspection PyTypeChecker
@@ -100,6 +101,7 @@ class ScriptGroupsConfig:
 def _build_env_vars(json_object):
     sensitive_config_paths = [
         ['auth', 'secret'],
+        ['access', 'user_header_secret'],
         ['alerts', 'destinations', 'password'],
         ['callbacks', 'destinations', 'password']
     ]
@@ -167,10 +169,12 @@ def from_json(conf_path, temp_folder):
         allowed_users = access_config.get('allowed_users')
         user_groups = model_helper.read_dict(access_config, 'groups')
         user_header_name = access_config.get('user_header_name')
+        user_header_secret = _parse_user_header_secret(access_config)
     else:
         allowed_users = None
         user_groups = {}
         user_header_name = None
+        user_header_secret = None
 
     auth_config = json_object.get('auth')
     if auth_config:
@@ -213,7 +217,16 @@ def from_json(conf_path, temp_folder):
     config.full_history_users = full_history_users
     config.code_editor_users = code_editor_users
     config.user_header_name = user_header_name
+    config.user_header_secret = user_header_secret
     config.ip_validator = TrustedIpValidator(trusted_ips)
+
+    if not auth_config:
+        if user_header_name and not user_header_secret:
+            LOGGER.warning('access.user_header_name is configured without access.user_header_secret: '
+                           'the header will be ignored and trusted-IP clients will get an anonymous identity '
+                           'instead. Configure access.user_header_secret to enable header-based identity.')
+        elif user_header_secret and not user_header_name:
+            LOGGER.warning('access.user_header_secret has no effect without access.user_header_name')
 
     config.max_request_size_mb = read_int_from_config('max_request_size', json_object, default=10)
 
@@ -283,6 +296,26 @@ def _prepare_allowed_users(allowed_users, admin_users, user_groups):
                 coerced_users.update(users)
 
     return list(coerced_users)
+
+
+def _parse_user_header_secret(access_config):
+    raw_secret = access_config.get('user_header_secret')
+    if raw_secret is None:
+        return None
+
+    if not isinstance(raw_secret, str):
+        raise InvalidServerConfigException('access.user_header_secret should be a string')
+
+    secret = model_helper.resolve_env_vars(raw_secret, full_match=True)
+    if (secret is None) or (not secret.strip()):
+        raise InvalidServerConfigException('access.user_header_secret should be a non-empty string')
+
+    secret = secret.strip()
+    if len(secret) < 16:
+        LOGGER.warning('access.user_header_secret is shorter than 16 characters, '
+                       'please use a long random value')
+
+    return secret
 
 
 def _parse_admin_users(json_object, default_admins=None):

--- a/src/tests/ip_idenfication_test.py
+++ b/src/tests/ip_idenfication_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from auth.identification import IpBasedIdentification
+from auth.identification import InvalidUserHeaderSecretException, IpBasedIdentification
 from auth.tornado_auth import TornadoAuth
 from model.trusted_ips import TrustedIpValidator
 from tests.test_utils import mock_object
@@ -9,12 +9,14 @@ from utils import date_utils
 COOKIE_KEY = 'client_id_token'
 
 
-def mock_request_handler(ip=None, x_forwarded_for=None, x_real_ip=None, saved_token=None, user_header_name=None, user_header_name_value=None):
+def mock_request_handler(ip=None, x_forwarded_for=None, x_real_ip=None, saved_token=None, user_header_name=None, user_header_name_value=None, proxy_secret=None):
     handler_mock = mock_object()
 
     handler_mock.application = mock_object()
     handler_mock.application.auth = TornadoAuth(None)
     handler_mock.application.identification = IpBasedIdentification(TrustedIpValidator(['127.0.0.1']), user_header_name)
+    handler_mock.application.server_config = mock_object()
+    handler_mock.application.server_config.cookie_secure = False
 
     handler_mock.request = mock_object()
     handler_mock.request.headers = {}
@@ -30,6 +32,9 @@ def mock_request_handler(ip=None, x_forwarded_for=None, x_real_ip=None, saved_to
     if user_header_name and user_header_name_value:
         handler_mock.request.headers[user_header_name] = user_header_name_value
 
+    if proxy_secret:
+        handler_mock.request.headers[IpBasedIdentification.PROXY_SECRET_HEADER] = proxy_secret
+
     cookies = {COOKIE_KEY: saved_token}
 
     def get_secure_cookie(name):
@@ -38,7 +43,7 @@ def mock_request_handler(ip=None, x_forwarded_for=None, x_real_ip=None, saved_to
             return values.encode('utf8')
         return None
 
-    def set_secure_cookie(key, value, expires_days=30):
+    def set_secure_cookie(key, value, expires_days=30, **kwargs):
         cookies[key] = value
 
     def clear_cookie(key):
@@ -185,3 +190,72 @@ class IpIdentificationTest(unittest.TestCase):
 
         self.assertNotEqual('something', id)
         self.assertNotEqual(new_token, 'something&100000')
+
+
+USER_HEADER_NAME = 'X-Forwarded-User'
+PROXY_SECRET = 'test-proxy-secret-0123456789'
+
+
+class UserHeaderSecretTest(unittest.TestCase):
+
+    @staticmethod
+    def create_identification(secret=PROXY_SECRET):
+        return IpBasedIdentification(TrustedIpValidator(['127.0.0.1']), USER_HEADER_NAME, user_header_secret=secret)
+
+    @staticmethod
+    def create_request_handler(user='admin_user', proxy_secret=None):
+        return mock_request_handler(
+            ip='127.0.0.1',
+            user_header_name=USER_HEADER_NAME,
+            user_header_name_value=user,
+            proxy_secret=proxy_secret)
+
+    def test_user_header_when_no_secret_configured(self):
+        request_handler = self.create_request_handler()
+        id = self.create_identification(secret=None).identify(request_handler)
+        self.assertNotEqual('admin_user', id)
+        self.assertEqual('127.0.0.1', id)
+
+    def test_user_header_when_correct_secret(self):
+        request_handler = self.create_request_handler(proxy_secret=PROXY_SECRET)
+        id = self.create_identification().identify(request_handler)
+        self.assertEqual('admin_user', id)
+
+    def test_user_header_when_missing_secret(self):
+        request_handler = self.create_request_handler()
+        self.assertRaises(InvalidUserHeaderSecretException, self.create_identification().identify, request_handler)
+
+    def test_user_header_when_wrong_secret(self):
+        request_handler = self.create_request_handler(proxy_secret='wrong-secret-0123456789')
+        self.assertRaises(InvalidUserHeaderSecretException, self.create_identification().identify, request_handler)
+
+    def test_no_user_header_when_secret_configured(self):
+        request_handler = mock_request_handler(ip='127.0.0.1')
+        id = self.create_identification().identify(request_handler)
+        self.assertEqual('127.0.0.1', id)
+
+    def test_untrusted_ip_when_secret_configured(self):
+        request_handler = mock_request_handler(ip='192.168.21.13')
+        id = self.create_identification().identify(request_handler)
+        self.assertNotEqual('admin_user', id)
+        self.assertNotEqual('192.168.21.13', id)
+
+    def test_audit_when_no_secret_configured(self):
+        request_handler = self.create_request_handler()
+        id = self.create_identification(secret=None).identify_for_audit(request_handler)
+        self.assertIsNone(id)
+
+    def test_audit_when_correct_secret(self):
+        request_handler = self.create_request_handler(proxy_secret=PROXY_SECRET)
+        id = self.create_identification().identify_for_audit(request_handler)
+        self.assertEqual('admin_user', id)
+
+    def test_audit_when_missing_secret(self):
+        request_handler = self.create_request_handler()
+        id = self.create_identification().identify_for_audit(request_handler)
+        self.assertIsNone(id)
+
+    def test_audit_when_wrong_secret(self):
+        request_handler = self.create_request_handler(proxy_secret='wrong-secret-0123456789')
+        id = self.create_identification().identify_for_audit(request_handler)
+        self.assertIsNone(id)

--- a/src/tests/server_conf_test.py
+++ b/src/tests/server_conf_test.py
@@ -455,6 +455,68 @@ class TestEnvVariables(unittest.TestCase):
                 'server': 'some_server'}
 
 
+class TestUserHeaderSecret(unittest.TestCase):
+    def setUp(self) -> None:
+        test_utils.setup()
+
+    def tearDown(self) -> None:
+        test_utils.cleanup()
+
+    def test_missing_when_no_access_section(self):
+        config = _from_json({})
+        self.assertIsNone(config.user_header_secret)
+
+    def test_missing_when_access_exists_without_secret(self):
+        config = _from_json({'access': {'user_header_name': 'X-Forwarded-User'}})
+        self.assertIsNone(config.user_header_secret)
+
+    def test_secret_value(self):
+        config = _from_json({'access': {
+            'user_header_name': 'X-Forwarded-User',
+            'user_header_secret': 'abcdefgh12345678'}})
+        self.assertEqual('abcdefgh12345678', config.user_header_secret)
+
+    def test_secret_from_env_variable(self):
+        test_utils.set_os_environ_value('HEADER_SECRET', 'env-secret-0123456789')
+
+        config = _from_json({'access': {
+            'user_header_name': 'X-Forwarded-User',
+            'user_header_secret': '$$HEADER_SECRET'}})
+
+        self.assertEqual('env-secret-0123456789', config.user_header_secret)
+        self.assertNotIn('HEADER_SECRET', config.env_vars.build_env_vars())
+
+    def test_empty_secret_not_allowed(self):
+        self.assertRaises(
+            server_conf.InvalidServerConfigException,
+            _from_json,
+            {'access': {'user_header_name': 'X-Forwarded-User', 'user_header_secret': '  '}})
+
+    def test_non_string_secret_not_allowed(self):
+        self.assertRaises(
+            server_conf.InvalidServerConfigException,
+            _from_json,
+            {'access': {'user_header_name': 'X-Forwarded-User', 'user_header_secret': 12345}})
+
+    def test_warning_when_user_header_without_secret(self):
+        with self.assertLogs('server_conf', level='WARNING') as log_context:
+            _from_json({'access': {'user_header_name': 'X-Forwarded-User'}})
+        self.assertTrue(any('user_header_secret' in line for line in log_context.output))
+
+    def test_warning_when_short_secret(self):
+        with self.assertLogs('server_conf', level='WARNING') as log_context:
+            _from_json({'access': {
+                'user_header_name': 'X-Forwarded-User',
+                'user_header_secret': 'short'}})
+        self.assertTrue(any('16 characters' in line for line in log_context.output))
+
+    def test_no_warning_when_secret_configured(self):
+        with self.assertNoLogs('server_conf', level='WARNING'):
+            _from_json({'access': {
+                'user_header_name': 'X-Forwarded-User',
+                'user_header_secret': 'abcdefgh12345678'}})
+
+
 def _from_json(content):
     json_obj = json.dumps(content)
     conf_path = os.path.join(test_utils.temp_folder, 'conf.json')

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -821,7 +821,9 @@ def init(server_config: ServerConfig,
     if auth.is_enabled():
         identification = AuthBasedIdentification(auth)
     else:
-        identification = IpBasedIdentification(server_config.ip_validator, server_config.user_header_name)
+        identification = IpBasedIdentification(server_config.ip_validator,
+                                               server_config.user_header_name,
+                                               user_header_secret=server_config.user_header_secret)
 
     downloads_folder = file_download_feature.get_result_files_folder()
 


### PR DESCRIPTION
## Summary
- In IP-based (no-login) identification, any client reachable from a `trusted_ips` address — which can be a CIDR range covering far more than just a reverse proxy — could set the `access.user_header_name` header to any username, including an admin, with no verification whatsoever.
- Adds an optional `access.user_header_secret`. When set, the request must also carry a matching `X-ScriptServer-Proxy-Secret` header (compared with `hmac.compare_digest`) before the identity header is trusted.
- A present identity header with a missing/wrong secret now hard-fails the request (`InvalidUserHeaderSecretException`) rather than silently degrading to a weaker identity path.
- **Behavior change**: if `user_header_name` is configured *without* `user_header_secret`, the header is now ignored entirely — the request falls back to the anonymous per-IP identity instead of being trusted by default. This closes the hole for anyone who hasn't yet configured the secret, rather than leaving the insecure default silently in place. A startup warning flags this misconfiguration.
- `user_header_secret` supports `$$ENV_VAR` indirection (same pattern as `auth.secret`) and is hidden from scripts' environments like other sensitive config paths.

## Test plan
- [x] `pytest tests/ip_idenfication_test.py tests/server_conf_test.py` — 97 passed (1 pre-existing unrelated failure: `test_htpasswd_auth`, missing `crypt` module in this venv, confirmed present on master too)
- [x] New tests cover: correct secret accepted; missing/wrong secret hard-fails; no secret configured → header ignored, falls back to anonymous identity; no identity header → unaffected; untrusted IP → unaffected; same matrix for `identify_for_audit`
- [x] Config parsing tests: env-var resolution, secret hidden from script env, empty/non-string secret rejected at startup, short-secret warning, "configured without secret" warning, "secret without header name" warning